### PR TITLE
Conversion Reference -> Conversion Matrix

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -1,4 +1,4 @@
-# Conversion reference
+# Conversion Matrix
 
 This document outlines all possible conversion details regarding `docker-compose.yaml` values to Kubernetes / OpenShift artifacts. This includes version 1, 2 and 3 of Docker Compose.
 


### PR DESCRIPTION
Initialize a documentation build (running the script on travis) as well
as change from Conversion Reference to Conversion Matrix.