### PR TITLE
Update doc script

### DIFF
--- a/script/sync-docs.sh
+++ b/script/sync-docs.sh
@@ -65,7 +65,7 @@ for filename in *.md; do
     jekyll="---
 layout: default
 permalink: /$name/
-redirect_from: \"/docs/$name/\"
+redirect_from: \"/docs/$name.md\"
 ---
 "
     echo -e "$jekyll\n$(cat $filename)" > $filename


### PR DESCRIPTION
Redirection works for http://kompose.io/docs/conversion/ but not for
http://kompose.io/docs/conversion.md which is what I originally
intended.

This PR updates the script to redirect all `.md` doc links.