### PR TITLE
Add tests for deploy key specifically

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -399,6 +399,9 @@ cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  "$KOMPOSE_ROOT/script/test/fixtures/v3/output-memcpu-k8s.json" > /tmp/output-k8s.json
 convert::expect_success "kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-memcpu.yaml" "/tmp/output-k8s.json"
 
+# Test deploy keys are psased correctly
+convert::expect_success "kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-deploy.yaml" "$KOMPOSE_ROOT/script/test/fixtures/v3/output-deploy-k8s.json"
+
 # Test volumes are passed correctly
 cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-volumes.yaml"
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/v3/output-volumes-k8s-template.json > /tmp/output-k8s.json

--- a/script/test/fixtures/v3/docker-compose-deploy.yaml
+++ b/script/test/fixtures/v3/docker-compose-deploy.yaml
@@ -1,0 +1,31 @@
+version: "3"
+
+services:
+
+  foo:
+    image: foo/bar
+    deploy:
+      mode: replicated
+      replicas: 6
+      labels: [FOO=BAR]
+      update_config:
+        parallelism: 3
+        delay: 10s
+        failure_action: continue
+        monitor: 60s
+        max_failure_ratio: 0.3
+      resources:
+        limits:
+          cpus: '0.001'
+          memory: 50M
+        reservations:
+          cpus: '0.0001'
+          memory: 20M
+      restart_policy:
+        # Disable in order to test "replicas"
+        # condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
+      placement:
+        constraints: [node=foo]

--- a/script/test/fixtures/v3/output-deploy-k8s.json
+++ b/script/test/fixtures/v3/output-deploy-k8s.json
@@ -1,0 +1,72 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "foo"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        }
+      },
+      "spec": {
+        "replicas": 6,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "foo"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "foo",
+                "image": "foo/bar",
+                "resources": {
+                  "limits": {
+                    "memory": "52428800"
+                  }
+                }
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
Due to:
https://github.com/kubernetes/kompose/commit/9dcb2bfba6639c045022d732d49867689ebb1de9
tests for "replicas" was disabled due to generating "pod-only"
kubernetes artifacts as per "restart_policy" being added.

This PR adds "deploy" tests so we can effectively test `replicas`