### PR TITLE
Updates the conversion document to reflect changes

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -1,65 +1,80 @@
 # Conversion Matrix
 
-This document outlines all possible conversion details regarding `docker-compose.yaml` values to Kubernetes / OpenShift artifacts. This includes version 1, 2 and 3 of Docker Compose.
+This document outlines all possible conversion details regarding `docker-compose.yaml` values to Kubernetes / OpenShift artifacts. This convers *major* versions of Docker Compose such as 1, 2 and 3.
+
+__Note:__ due to the fast-pace nature of Docker Compose version revisions, minor versions such as 2.1, 2.2, 3.1, 3.2 or 3.3 are not supported until they are cut into a major version release such as 2 or 3.
+
+__Glossary:__
+__Y:__ Converts
+__N:__ Not yet implemented
+__N/A:__ Not applicable / no 1-1 conversion
 
 | Value             | Support | K8s / OpenShift                                                  | Notes                                                                                                          |
 |-------------------|---------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| SERVICE           |         |                                                                  |                                                                                                                |
-| build             | Y       | OpenShift: BuildConfig                                           | Converts, but local builds are not yet supported. See issue 97                                                 |
+| __Service__       |         |                                                                  |                                                                                                                |
+| build             | Y       | Builds/Pushes to Docker repository. See `--build` parameter      | Only supported on Version 1/2 of Docker Compose                                                                |
 | cap_add, cap_drop | Y       | Pod.Spec.Container.SecurityContext.Capabilities.Add/Drop         |                                                                                                                |
 | command           | Y       | Pod.Spec.Container.Command                                       |                                                                                                                |
-| cgroup_parent     | N       |                                                                  | No compatibility with Kubernetes / OpenShift. Limited use-cases with Docker.                                   |
-| container_name    | Y       | Mapped to both Metadata.Name and Deployment.Spec.Containers.Name |                                                                                                                |
-| deploy            | N       |                                                                  | Upcoming support started                                                                                       |
-| devices           | N       |                                                                  | Not supported within Kubernetes, see this issue                                                                |
-| depends_on        | N       |                                                                  |                                                                                                                |
-| dns               | N       |                                                                  |                                                                                                                |
-| dns_search        | N       |                                                                  |                                                                                                                |
+| cgroup_parent     | N/A     |                                                                  | Not supported within Kubernetes. See issue https://github.com/kubernetes/kubernetes/issues/11986               |
+| container_name    | Y       | Metadata.Name + Deployment.Spec.Containers.Name                  |                                                                                                                |
+| devices           | N/A     |                                                                  | Not supported within Kubernetes, See issue https://github.com/kubernetes/kubernetes/issues/5607                |
+| depends_on        | N/A     |                                                                  |                                                                                                                |
+| dns               | N/A     |                                                                  | Not used within Kubernetes. Kubernetes uses a managed DNS server                                               |
+| dns_search        | N/A     |                                                                  | See `dns` key                                                                                                  |
 | tmpfs             | Y       | Pod.Spec.Containers.Volumes.EmptyDir                             | Creates emptyDirvolume with medium set to Memory & mounts given directory inside container                     |
 | entrypoint        | Y       | Pod.Spec.Container.Command                                       | Same as command                                                                                                |
 | env_file          | N       |                                                                  |                                                                                                                |
 | environment       | Y       | Pod.Spec.Container.Env                                           |                                                                                                                |
 | expose            | Y       | Service.Spec.Ports                                               |                                                                                                                |
 | extends           | Y       |                                                                  | Extends by utilizing the same image supplied                                                                   |
-| external_links    | N       |                                                                  |                                                                                                                |
+| external_links    | N/A     |                                                                  | Kubernetes uses a flat-structure for all containers and thus external_links does not have a 1-1 conversion     |
 | extra_hosts       | N       |                                                                  |                                                                                                                |
 | group_add         | N       |                                                                  |                                                                                                                |
 | healthcheck       | N       |                                                                  |                                                                                                                |
 | image             | Y       | Deployment.Spec.Containers.Image                                 |                                                                                                                |
-| isolation         | N       |                                                                  |                                                                                                                |
+| isolation         | N/A     |                                                                  | Not applicable as this applies to Windows with HyperV support                                                  |
 | labels            | Y       | Metadata.Annotations                                             |                                                                                                                |
-| links             | N       |                                                                  |                                                                                                                |
-| logging           | N       |                                                                  |                                                                                                                |
-| network_mode      | N       |                                                                  |                                                                                                                |
-| networks          | N       |                                                                  |                                                                                                                |
+| links             | N/A     |                                                                  | All containers in the same pod are accessible in Kubernetes                                                    |
+| logging           | N/A     |                                                                  | Kubernetes has built-in logging support at the node-level                                                      |
+| network_mode      | N/A     |                                                                  | Kubernetes uses it's own cluster networking                                                                    |
+| networks          | N/A     |                                                                  | See `networks` key                                                                                             |
 | pid               | Y       | Pod.Spec.HostPID                                                 |                                                                                                                |
 | ports             | Y       | Service.Spec.Ports                                               |                                                                                                                |
-| security_opt      | N       |                                                                  |                                                                                                                |
+| security_opt      | N/A     |                                                                  | Kubernetes uses it's own container naming scheme                                                               |
 | stop_grace_period | Y       | Pod.Spec.TerminationGracePeriodSeconds                           |                                                                                                                |
-| stop_signal       | N       |                                                                  |                                                                                                                |
+| stop_signal       | N/A     |                                                                  | Not supported within Kubernetes. See issue https://github.com/kubernetes/kubernetes/issues/30051               |
 | sysctls           | N       |                                                                  |                                                                                                                |
-| ulimits           | N       |                                                                  | See this issue on the k8s repo                                                                                 |
-| userns_mode       | N       |                                                                  |                                                                                                                |
+| ulimits           | N/A     |                                                                  | Not supported within Kubernetes. See issue https://github.com/kubernetes/kubernetes/issues/3595                |
+| userns_mode       | N/A     |                                                                  | Not supported within Kubernetes and ignored in Docker Compose Version 3                                        |
 | volumes           | Y       | PersistentVolumeClaim                                            | Creates a PersistentVolumeClaim. Can only be created if there is already a PersistentVolume within the cluster |
-| volume_driver     | N       |                                                                  |                                                                                                                |
+| volume_driver     | N/A     |                                                                  | Different plugins for different volumes, see: https://kubernetes.io/docs/concepts/storage/volumes/             |
 | volumes_from      | Y       | PersistentVolumeClaim                                            | Creates a PersistentVolumeClaim that is both shared by deployment and deployment config (OpenShift)            |
-| cpu_shares        | N       |                                                                  |                                                                                                                |
-| cpu_quota         | N       |                                                                  |                                                                                                                |
-| cpuset            | N       |                                                                  |                                                                                                                |
-| mem_limit         | Y       | …Containers.Resources.Limits.Memory                              |                                                                                                                |
-| memswap_limit     | N       |                                                                  | Use mem_limit                                                                                                  |
+| cpu_shares        | N/A     |                                                                  | No direct mapping, use `resources` key within Docker Compose Version 3 `deploy`                                |
+| cpu_quota         | N/A     |                                                                  | No direct mapping, use `resources` key within Docker Compose Version 3 `deploy`                                |
+| cpuset            | N/A     |                                                                  | No direct mapping, use `resources` key within Docker Compose Version 3 `deploy`                                |
+| mem_limit         | Y       | Containers.Resources.Limits.Memory                               |                                                                                                                |
+| memswap_limit     | N/A     |                                                                  | Use mem_limit                                                                                                  |
 |                   |         |                                                                  |                                                                                                                |
-| VOLUME            |         |                                                                  |                                                                                                                |
-| driver            | N       |                                                                  |                                                                                                                |
-| driver_opts       | N       |                                                                  |                                                                                                                |
-| external          | N       |                                                                  |                                                                                                                |
+| __Deploy__        |         |                                                                  |                                                                                                                |
+| mode              | N       |                                                                  |                                                                                                                |
+| replicas          | Y       | Deployment.Spec.Replicas / DeploymentConfig.Spec.Replicas        |                                                                                                                |
+| placement         | N       |                                                                  |                                                                                                                |
+| update_config     | N       |                                                                  |                                                                                                                |
+| resources         | Y       | Containers.Resources.Limits.Memory                               | Support for memory but not CPU                                                                                 |
+| restart_policy    | Y       | Pod generation                                                   | This generated a Pod, see the [user guide on restart](http://kompose.io/user-guide/#restart)                   |
 | labels            | N       |                                                                  |                                                                                                                |
 |                   |         |                                                                  |                                                                                                                |
-| NETWORK           |         |                                                                  |                                                                                                                |
-| driver            | N       |                                                                  |                                                                                                                |
-| driver_opts       | N       |                                                                  |                                                                                                                |
-| enable_ipv6       | N       |                                                                  |                                                                                                                |
-| ipam              | N       |                                                                  |                                                                                                                |
-| internal          | N       |                                                                  |                                                                                                                |
-| labels            | N       |                                                                  |                                                                                                                |
-| external          | N       |                                                                  |                                                                                                                |
+| __Volume__        | N/A     |                                                                  |                                                                                                                |
+| driver            | N/A     |                                                                  |                                                                                                                |
+| driver_opts       | N/A     |                                                                  |                                                                                                                |
+| external          | N/A     |                                                                  |                                                                                                                |
+| labels            | N/A     |                                                                  |                                                                                                                |
+|                   |         |                                                                  |                                                                                                                |
+| __Network__       | N/A     |                                                                  |                                                                                                                |
+| driver            | N/A     |                                                                  |                                                                                                                |
+| driver_opts       | N/A     |                                                                  |                                                                                                                |
+| enable_ipv6       | N/A     |                                                                  |                                                                                                                |
+| ipam              | N/A     |                                                                  |                                                                                                                |
+| internal          | N/A     |                                                                  |                                                                                                                |
+| labels            | N/A     |                                                                  |                                                                                                                |
+| external          | N/A     |                                                                  |                                                                                                                |


### PR DESCRIPTION
This updates the conversion document to outline that we do not support
minor versions since libcompose does not support 2.1 or 2.2 as well as
constant changes to docker/cli stack code regarding 3.1 and above.

I also update the conversion document to better reflect our support on
version 3 as well as update current values.