### PR TITLE
Add gitlawr to mention bot blacklist

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -3,7 +3,7 @@
   "numFilesToCheck": 5,
   "message": "@pullRequester, thank you for the pull request! We'll ping some people to review your PR. @reviewers, please review this.",
   "fileBlacklist": ["*.md"],
-  "userBlacklist": ["ngtuna", "janetkuo", "sebgoa", "dustymabe"],
+  "userBlacklist": ["ngtuna", "janetkuo", "sebgoa", "dustymabe", "gitlawr"],
   "actions": ["opened", "labeled"],
   "skipAlreadyMentionedPR": true,
   "createReviewRequest": true


### PR DESCRIPTION
Let's try to keep it to active contributors / maintainers so people
aren't needlessly pinged :)