### PR TITLE
Add integration doc

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,33 @@
+# Integrations
+
+There are some projects out there known to use Kompose integrated in some form or another
+
+### Kompose UI by Jad Chamoun (ICANN)
+
+__Description:__ "A web interface to convert Docker Compose files to Kubernetes YAML"
+
+__Link:__ https://github.com/JadCham/komposeui
+
+### Kompose Docker Container by Cloudfind
+
+__Description:__ "A Docker container for the Kompose translator for docker-compose"
+
+__Link:__ https://github.com/cloudfind/kompose-docker
+
+### KPM by CoreOS
+
+__Description:__ "KPM is a tool to deploy and manage application stacks on Kubernetes"
+
+__Link:__ https://github.com/coreos/kpm
+
+### Docker Image for Adobe Enterprise Manager by Adfinis SysGroup AG
+
+__Description:__ "Docker Image for Adobe Enterprise Manager"
+
+__Link:__ https://github.com/adfinis-sygroup/aem-docker/tree/master
+
+### Kompose Ansible Playbook by Chris Houseknecht (Red Hat)
+
+__Description:__  "Download and unarchive the latest kompose release asset for your OS"
+
+__Link:__ https://github.com/chouseknecht/kompose-install-role


### PR DESCRIPTION
Adds an integration document that lists third-party organizations /
users that use Kompose in some-way or another.