### PR TITLE
Update integrations links

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -6,28 +6,28 @@ There are some projects out there known to use Kompose integrated in some form o
 
 __Description:__ "A web interface to convert Docker Compose files to Kubernetes YAML"
 
-__Link:__ https://github.com/JadCham/komposeui
+__Link:__ [https://github.com/JadCham/komposeui](https://github.com/JadCham/komposeui)
 
 ### Kompose Docker Container by Cloudfind
 
 __Description:__ "A Docker container for the Kompose translator for docker-compose"
 
-__Link:__ https://github.com/cloudfind/kompose-docker
+__Link:__ [https://github.com/cloudfind/kompose-docker](https://github.com/JadCham/komposeui)
 
 ### KPM by CoreOS
 
 __Description:__ "KPM is a tool to deploy and manage application stacks on Kubernetes"
 
-__Link:__ https://github.com/coreos/kpm
+__Link:__ [https://github.com/coreos/kpm](https://github.com/coreos/kpm)
 
 ### Docker Image for Adobe Enterprise Manager by Adfinis SysGroup AG
 
 __Description:__ "Docker Image for Adobe Enterprise Manager"
 
-__Link:__ https://github.com/adfinis-sygroup/aem-docker/tree/master
+__Link:__ [https://github.com/adfinis-sygroup/aem-docker/tree/master](https://github.com/adfinis-sygroup/aem-docker/tree/master)
 
 ### Kompose Ansible Playbook by Chris Houseknecht (Red Hat)
 
 __Description:__  "Download and unarchive the latest kompose release asset for your OS"
 
-__Link:__ https://github.com/chouseknecht/kompose-install-role
+__Link:__ [https://github.com/chouseknecht/kompose-install-role](https://github.com/chouseknecht/kompose-install-role)


### PR DESCRIPTION
Jekyll doesn't support automatically linking, so we have to manually add
the links here.