### PR TITLE
Update cluster tests, use local Kompose binary

### DIFF
--- a/script/test_ci/test.sh
+++ b/script/test_ci/test.sh
@@ -22,7 +22,8 @@ if ! hash kubectl 2>/dev/null; then
 fi
 
 # First off, we have to compile the latest binary
-make bin
+# We *assume* that the binary has already been built
+# make bin
 
 #####################
 # KUBERNETES TESTS ##

--- a/script/test_in_openshift/lib.sh
+++ b/script/test_in_openshift/lib.sh
@@ -192,7 +192,7 @@ function convert::kompose_up () {
     # Usage: convert::kompose_up <docker_compose_file>
     local compose_file=$1
     convert::print_msg "Running kompose up ..."
-    kompose up --provider=openshift --emptyvols -f $compose_file
+    ./kompose up --provider=openshift --emptyvols -f $compose_file
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then
@@ -206,7 +206,7 @@ function convert::kompose_down () {
     # Usage: convert::kompose_down <docker_compose_file>
     local compose_file=$1
     convert::print_msg "Running kompose down ..."
-    kompose --provider=openshift -f $compose_file down
+    ./kompose --provider=openshift -f $compose_file down
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then

--- a/script/test_in_openshift/tests/redis-replica-2.sh
+++ b/script/test_in_openshift/tests/redis-replica-2.sh
@@ -23,7 +23,7 @@ source $KOMPOSE_ROOT/script/test_in_openshift/lib.sh
 convert::print_msg "Running tests for replica option"
 
 # Run kompose up
-kompose up --provider=openshift --emptyvols --replicas 2 -f ${KOMPOSE_ROOT}/examples/docker-compose-counter.yaml; exit_status=$?
+./kompose up --provider=openshift --emptyvols --replicas 2 -f ${KOMPOSE_ROOT}/examples/docker-compose-counter.yaml; exit_status=$?
 
 if [ $exit_status -ne 0 ]; then
     convert::print_fail "kompose up has failed"


### PR DESCRIPTION
Uses the local kompose binary that was built, not the one stored in the
GOPATH bin folder.

For example, using `./kompose` instead of `kompose`

Disables `make bin` generation for Kubernetes tests.