### PR TITLE
Adds healthcheck

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -49,7 +49,7 @@ __Glossary:__
 | external_links         | X  | X  | X  |                                                             | Kubernetes uses a flat-structure for all containers and thus external_links does not have a 1-1 conversion     |
 | extra_hosts            | N  | N  | N  |                                                             |                                                                                                                |
 | group_add              | ✓  | ✓  | ✓  |                                                             |                                                                                                                |
-| healthcheck            | -  | N  | N  |                                                             |                                                                                                                |
+| healthcheck            | -  | N  | ✓  |                                                             |                                                                                                                |
 | image                  | ✓  | ✓  | ✓  | Deployment.Spec.Containers.Image                            |                                                                                                                |
 | isolation              | X  | X  | X  |                                                             | Not applicable as this applies to Windows with HyperV support                                                  |
 | labels                 | ✓  | ✓  | ✓  | Metadata.Annotations                                        |                                                                                                                |

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -99,8 +99,20 @@ type ServiceConfig struct {
 	Dockerfile      string              `compose:"dockerfile"`
 	Replicas        int                 `compose:"replicas"`
 	GroupAdd        []int64             `compose:"group_add"`
-	// Volumes is a struct which contains all information about each volume
-	Volumes []Volumes `compose:""`
+	Volumes         []Volumes           `compose:""`
+	HealthChecks    HealthCheck         `compose:""`
+}
+
+// HealthCheck the healthcheck configuration for a service
+// "StartPeriod" is not yet added to compose, see:
+// https://github.com/docker/cli/issues/116
+type HealthCheck struct {
+	Test        []string
+	Timeout     int32
+	Interval    int32
+	Retries     int32
+	StartPeriod int32
+	Disable     bool
 }
 
 // EnvVar holds the environment variable struct of a container

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -32,6 +32,34 @@ import (
 	"github.com/pkg/errors"
 )
 
+func TestParseHealthCheck(t *testing.T) {
+	helperValue := uint64(2)
+	check := types.HealthCheckConfig{
+		Test:        []string{"CMD-SHELL", "echo", "foobar"},
+		Timeout:     "1s",
+		Interval:    "2s",
+		Retries:     &helperValue,
+		StartPeriod: "3s",
+	}
+
+	// CMD-SHELL or SHELL is included Test within docker/cli, thus we remove the first value in Test
+	expected := kobject.HealthCheck{
+		Test:        []string{"echo", "foobar"},
+		Timeout:     1,
+		Interval:    2,
+		Retries:     2,
+		StartPeriod: 3,
+	}
+	output, err := parseHealthCheck(check)
+	if err != nil {
+		t.Errorf("Unable to convert HealthCheckConfig: %s", err)
+	}
+
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("Structs are not equal, expected: %s, output: %s", expected, output)
+	}
+}
+
 func TestLoadV3Volumes(t *testing.T) {
 	vol := types.ServiceVolumeConfig{
 		Type:     "volume",
@@ -66,6 +94,7 @@ func TestLoadV3Ports(t *testing.T) {
 	if output[0] != expected {
 		t.Errorf("Expected %v, got %v", expected, output[0])
 	}
+
 }
 
 // Test if service types are parsed properly on user input

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -392,6 +392,15 @@ convert::expect_success "kompose --provider=openshift convert --stdout -j" "/tmp
 # Return back to the original path
 cd $CURRENT_DIR
 
+# Test HealthCheck
+cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/healthcheck/docker-compose.yaml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  "$KOMPOSE_ROOT/script/test/fixtures/healthcheck/output-k8s-template.json" > /tmp/output-k8s.json
+convert::expect_success "kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/healthcheck/docker-compose.yaml" "/tmp/output-k8s.json"
+
+cmd="kompose convert --stdout -j --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/healthcheck/docker-compose.yaml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  "$KOMPOSE_ROOT/script/test/fixtures/healthcheck/output-os-template.json" > /tmp/output-os.json
+convert::expect_success "kompose convert --stdout -j --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/healthcheck/docker-compose.yaml" "/tmp/output-os.json"
+
 # Test V3 Support of Docker Compose
 
 # Test deploy mode: global

--- a/script/test/fixtures/healthcheck/docker-compose.yaml
+++ b/script/test/fixtures/healthcheck/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  redis:
+    image: redis
+    healthcheck:
+      test: echo "hello world"
+      interval: 10s
+      timeout: 1s
+      retries: 5

--- a/script/test/fixtures/healthcheck/output-k8s-template.json
+++ b/script/test/fixtures/healthcheck/output-k8s-template.json
@@ -1,0 +1,86 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis",
+                "resources": {},
+                "livenessProbe": {
+                  "exec": {
+                    "command": [
+                      "echo \"hello world\""
+                    ]
+                  },
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "failureThreshold": 5
+                }
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/healthcheck/output-os-template.json
+++ b/script/test/fixtures/healthcheck/output-os-template.json
@@ -1,0 +1,138 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "redis"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "redis:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "redis"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": " ",
+                "resources": {},
+                "livenessProbe": {
+                  "exec": {
+                    "command": [
+                      "echo \"hello world\""
+                    ]
+                  },
+                  "timeoutSeconds": 1,
+                  "periodSeconds": 10,
+                  "failureThreshold": 5
+                }
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "redis"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}

--- a/script/test/fixtures/v3/output-k8s-full-example.json
+++ b/script/test/fixtures/v3/output-k8s-full-example.json
@@ -197,6 +197,16 @@
                 "mountPath": "/tmp"
               }
             ],
+            "livenessProbe": {
+              "exec": {
+                "command": [
+                  "echo \"hello world\""
+                ]
+              },
+              "timeoutSeconds": 1,
+              "periodSeconds": 10,
+              "failureThreshold": 5
+            },
             "securityContext": {
               "capabilities": {
                 "add": [

--- a/script/test/fixtures/v3/output-os-full-example.json
+++ b/script/test/fixtures/v3/output-os-full-example.json
@@ -197,6 +197,16 @@
                 "mountPath": "/tmp"
               }
             ],
+            "livenessProbe": {
+              "exec": {
+                "command": [
+                  "echo \"hello world\""
+                ]
+              },
+              "timeoutSeconds": 1,
+              "periodSeconds": 10,
+              "failureThreshold": 5
+            },
             "securityContext": {
               "capabilities": {
                 "add": [


### PR DESCRIPTION
This PR adds support for HealthCheck, being able to supply, for example:

```yaml
version: "3"

services:
  redis:
    image: redis
    healthcheck:
      test: echo "hello world"
      interval: 10s
      timeout: 1s
      retries: 5
```

Which is then converted to:

```yaml
spec:
  containers:
  - image: redis
    livenessProbe:
      exec:
        command:
        - echo "hello world"
      failureThreshold: 5
      periodSeconds: 10
      timeoutSeconds: 1
    name: redis
    resources: {}
  restartPolicy: Always
```

At the moment, this only supports livenessProbe, with support for readinessProbe in the future.