### PR TITLE
Add deploy: mode: global support

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -61,14 +61,13 @@ type ConvertOptions struct {
 // ServiceConfig holds the basic struct of a container
 type ServiceConfig struct {
 	// use tags to mark from what element this value comes
-	ContainerName string
-	Image         string   `compose:"image"`
-	Environment   []EnvVar `compose:"environment"`
-	Port          []Ports  `compose:"ports"`
-	Command       []string `compose:"command"`
-	WorkingDir    string   `compose:""`
-	Args          []string `compose:"args"`
-	// VolList is list of volumes extracted from docker-compose file
+	ContainerName   string
+	Image           string              `compose:"image"`
+	Environment     []EnvVar            `compose:"environment"`
+	Port            []Ports             `compose:"ports"`
+	Command         []string            `compose:"command"`
+	WorkingDir      string              `compose:""`
+	Args            []string            `compose:"args"`
 	VolList         []string            `compose:"volumes"`
 	Network         []string            `compose:"network"`
 	Labels          map[string]string   `compose:"labels"`
@@ -95,6 +94,7 @@ type ServiceConfig struct {
 	Tty             bool                `compose:"tty"`
 	MemLimit        yaml.MemStringorInt `compose:"mem_limit"`
 	MemReservation  yaml.MemStringorInt `compose:""`
+	DeployMode      string              `compose:""`
 	TmpFs           []string            `compose:"tmpfs"`
 	Dockerfile      string              `compose:"dockerfile"`
 	Replicas        int                 `compose:"replicas"`

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -198,6 +198,8 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 		// Deploy keys
 		//
 
+		serviceConfig.DeployMode = composeServiceConfig.Deploy.Mode
+
 		if (composeServiceConfig.Deploy.Resources != types.Resources{}) {
 
 			// memory:

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -490,10 +490,17 @@ func (k *Kubernetes) ConfigEnvs(name string, service kobject.ServiceConfig) []ap
 func (k *Kubernetes) CreateKubernetesObjects(name string, service kobject.ServiceConfig, opt kobject.ConvertOptions) []runtime.Object {
 	var objects []runtime.Object
 	var replica int
+
 	if opt.IsReplicaSetFlag || service.Replicas == 0 {
 		replica = opt.Replicas
 	} else {
 		replica = service.Replicas
+	}
+
+	// Check to see if Docker Compose v3 Deploy.Mode has been set to "global"
+	if service.DeployMode == "global" {
+		log.Warning("Global mode not yet supported, containers will only be replicated once throughout the cluster. DaemonSet support will be added in the future.")
+		replica = 1
 	}
 
 	if opt.CreateD {

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -272,6 +272,7 @@ func (o *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 	for _, name := range sortedKeys {
 		service := komposeObject.ServiceConfigs[name]
 		var objects []runtime.Object
+
 		//replicas
 		var replica int
 		if opt.IsReplicaSetFlag || service.Replicas == 0 {
@@ -279,6 +280,12 @@ func (o *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 		} else {
 			replica = service.Replicas
 		}
+
+		// If Deploy.Mode = Global has been set, make replica = 1 when generating DeploymentConfig
+		if service.DeployMode == "global" {
+			replica = 1
+		}
+
 		// Must build the images before conversion (got to add service.Image in case 'image' key isn't provided
 		// Check to see if there is an InputFile (required!) before we build the container
 		// Check that there's actually a Build key

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -394,6 +394,15 @@ cd $CURRENT_DIR
 
 # Test V3 Support of Docker Compose
 
+# Test deploy mode: global
+cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-deploy-mode.yaml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  "$KOMPOSE_ROOT/script/test/fixtures/v3/output-deploy-mode-k8s-template.json" > /tmp/output-k8s.json
+convert::expect_success_and_warning "kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-deploy-mode.yaml" "/tmp/output-k8s.json"
+
+cmd="kompose convert --stdout -j --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-deploy-mode.yaml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  "$KOMPOSE_ROOT/script/test/fixtures/v3/output-deploy-mode-os-template.json" > /tmp/output-os.json
+convert::expect_success_and_warning "kompose convert --stdout -j --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-deploy-mode.yaml" "/tmp/output-os.json"
+
 # Test support for cpu and memory limits + reservations
 cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose-memcpu.yaml"
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  "$KOMPOSE_ROOT/script/test/fixtures/v3/output-memcpu-k8s.json" > /tmp/output-k8s.json

--- a/script/test/fixtures/v3/docker-compose-deploy-mode.yaml
+++ b/script/test/fixtures/v3/docker-compose-deploy-mode.yaml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  foo:
+    deploy:
+      mode: global
+      replicas: 6
+    image: redis

--- a/script/test/fixtures/v3/output-deploy-mode-k8s-template.json
+++ b/script/test/fixtures/v3/output-deploy-mode-k8s-template.json
@@ -1,0 +1,76 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "foo"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "foo"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "foo",
+                "image": "redis",
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/v3/output-deploy-mode-os-template.json
+++ b/script/test/fixtures/v3/output-deploy-mode-os-template.json
@@ -1,0 +1,128 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "foo"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "foo"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "foo:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "foo"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "foo"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "foo",
+                "image": " ",
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "foo",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "foo"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "redis"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for deploy: mode.

For example:

```yaml
version: "3"

services:
  foo:
    deploy:
      resources:
        mode: global
        replicas: 6
    image: redis
```

Will only generate replicas: 1 in Kubernetes pods as "global" limits
replicas to only one.