### PR TITLE
Add --volumes parameter, deprecate emptyvols

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -32,6 +32,7 @@ var (
 	ConvertBuildRepo             string
 	ConvertBuildBranch           string
 	ConvertBuild                 string
+	ConvertVolumes               string
 	ConvertChart                 bool
 	ConvertDeployment            bool
 	ConvertDaemonSet             bool
@@ -78,6 +79,7 @@ var convertCmd = &cobra.Command{
 			BuildBranch:                 ConvertBuildBranch,
 			CreateDeploymentConfig:      ConvertDeploymentConfig,
 			EmptyVols:                   ConvertEmptyVols,
+			Volumes:                     ConvertVolumes,
 			InsecureRepository:          ConvertInsecureRepo,
 			IsDeploymentFlag:            cmd.Flags().Lookup("deployment").Changed,
 			IsDaemonSetFlag:             cmd.Flags().Lookup("daemon-set").Changed,
@@ -128,9 +130,13 @@ func init() {
 	convertCmd.Flags().MarkShorthandDeprecated("y", "YAML is the default format now.")
 	convertCmd.Flags().BoolVarP(&ConvertJSON, "json", "j", false, "Generate resource files into JSON format")
 	convertCmd.Flags().BoolVar(&ConvertStdout, "stdout", false, "Print converted objects to stdout")
-	convertCmd.Flags().BoolVar(&ConvertEmptyVols, "emptyvols", false, "Use Empty Volumes. Do not generate PVCs")
 	convertCmd.Flags().StringVarP(&ConvertOut, "out", "o", "", "Specify a file name to save objects to")
 	convertCmd.Flags().IntVar(&ConvertReplicas, "replicas", 1, "Specify the number of repliaces in the generate resource spec")
+	convertCmd.Flags().StringVar(&ConvertVolumes, "volumes", "persistentVolumeClaim", `Volumes to be generated ("persistentVolumeClaim"|"emptyDir")`)
+
+	// Deprecated commands
+	convertCmd.Flags().BoolVar(&ConvertEmptyVols, "emptyvols", false, "Use Empty Volumes. Do not generate PVCs")
+	convertCmd.Flags().MarkDeprecated("emptyvols", "emptyvols has been marked as deprecated. Use --volumes empty")
 
 	// In order to 'separate' both OpenShift and Kubernetes only flags. A custom help page is created
 	customHelp := `Usage:{{if .Runnable}}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -29,6 +29,7 @@ import (
 var (
 	UpReplicas     int
 	UpEmptyVols    bool
+	UpVolumes      string
 	UpInsecureRepo bool
 	UpNamespace    string
 	UpOpt          kobject.ConvertOptions
@@ -54,6 +55,7 @@ var upCmd = &cobra.Command{
 			InputFiles:         GlobalFiles,
 			Provider:           strings.ToLower(GlobalProvider),
 			EmptyVols:          UpEmptyVols,
+			Volumes:            UpVolumes,
 			Namespace:          UpNamespace,
 			InsecureRepository: UpInsecureRepo,
 			IsNamespaceFlag:    cmd.Flags().Lookup("namespace").Changed,
@@ -68,10 +70,15 @@ var upCmd = &cobra.Command{
 }
 
 func init() {
-	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use empty volumes. Do not generate PersistentVolumeClaim")
 	upCmd.Flags().IntVar(&UpReplicas, "replicas", 1, "Specify the number of replicas generated")
+	upCmd.Flags().StringVar(&UpVolumes, "volumes", "persistentVolumeClaim", `Volumes to be generated ("persistentVolumeClaim"|"emptyDir")`)
 	upCmd.Flags().BoolVar(&UpInsecureRepo, "insecure-repository", false, "Use an insecure Docker repository for OpenShift ImageStream")
 	upCmd.Flags().StringVar(&UpNamespace, "namespace", "default", "Specify Namespace to deploy your application")
 	upCmd.Flags().StringVar(&UpBuild, "build", "local", `Set the type of build ("local"|"build-config" (OpenShift only)|"none")`)
+
+	// Deprecated
+	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use empty volumes. Do not generate PersistentVolumeClaim")
+	upCmd.Flags().MarkDeprecated("emptyvols", "emptyvols has been marked as deprecated. Use --volumes empty")
+
 	RootCmd.AddCommand(upCmd)
 }

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -44,6 +44,7 @@ type ConvertOptions struct {
 	GenerateYaml                bool
 	GenerateJSON                bool
 	EmptyVols                   bool
+	Volumes                     string
 	InsecureRepository          bool
 	Replicas                    int
 	InputFiles                  []string

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -383,6 +383,10 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 	// as opposed to persistent volumes and volume claims
 	useEmptyVolumes := k.Opt.EmptyVols
 
+	if k.Opt.Volumes == "emptyDir" {
+		useEmptyVolumes = true
+	}
+
 	var count int
 	//interating over array of `Vols` struct as it contains all necessary information about volumes
 	for _, volume := range service.Volumes {
@@ -684,7 +688,7 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 	}
 
 	pvcStr := " "
-	if !opt.EmptyVols {
+	if !opt.EmptyVols || opt.Volumes != "emptyDir" {
 		pvcStr = " and PersistentVolumeClaims "
 	}
 	log.Info("We are going to create Kubernetes Deployments, Services" + pvcStr + "for your Dockerized application. " +
@@ -736,7 +740,7 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 		}
 	}
 
-	if !opt.EmptyVols {
+	if !opt.EmptyVols || opt.Volumes != "emptyDir" {
 		pvcStr = ",pvc"
 	} else {
 		pvcStr = ""

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -425,7 +425,7 @@ func (o *OpenShift) Deploy(komposeObject kobject.KomposeObject, opt kobject.Conv
 	}
 
 	pvcStr := " "
-	if !opt.EmptyVols {
+	if !opt.EmptyVols || opt.Volumes != "emptyDir" {
 		pvcStr = " and PersistentVolumeClaims "
 	}
 	log.Info("We are going to create OpenShift DeploymentConfigs, Services" + pvcStr + "for your Dockerized application. \n" +
@@ -493,7 +493,7 @@ func (o *OpenShift) Deploy(komposeObject kobject.KomposeObject, opt kobject.Conv
 		}
 	}
 
-	if !opt.EmptyVols {
+	if !opt.EmptyVols || opt.Volumes != "emptyDir" {
 		pvcStr = ",pvc"
 	} else {
 		pvcStr = ""

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -369,6 +369,10 @@ cmd="kompose convert --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-os-template.json > /tmp/output-os.json
 convert::expect_success_and_warning "kompose convert --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml --stdout -j" "/tmp/output-os.json" "Volume mount on the host "\"."\" isn't supported - ignoring path on the host"
 
+# Test that empty-vols works
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml --stdout -j --volumes emptyDir"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json > /tmp/output-k8s.json
+convert::expect_success_and_warning "kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml --stdout -j --volumes emptyDir" "/tmp/output-k8s.json" "Volume mount on the host "\"."\" isn't supported - ignoring path on the host"
 
 # Test related to support docker-compose.yaml beside docker-compose.yml
 # Store the original path

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json
@@ -1,0 +1,167 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis",
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "web-empty0",
+                "emptyDir": {}
+              }
+            ],
+            "containers": [
+              {
+                "name": "web",
+                "image": "flask_web",
+                "args": [
+                  "python",
+                  "app.py"
+                ],
+                "ports": [
+                  {
+                    "containerPort": 5000
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "web-empty0",
+                    "mountPath": "/code"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
This adds the --volumes paramater with a "generate" and "empty"

By default, "generate" will be used as a place-holder for "true".
Although not used in the code, we will eventually add "none"

This uses CLI paramater naming processes (no emptyVols as that is Go /
Kubernetes specific) and thus we use dashes.