### PR TITLE
Fix kompose docker container wrong href

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -12,7 +12,7 @@ __Link:__ [https://github.com/JadCham/komposeui](https://github.com/JadCham/komp
 
 __Description:__ "A Docker container for the Kompose translator for docker-compose"
 
-__Link:__ [https://github.com/cloudfind/kompose-docker](https://github.com/JadCham/komposeui)
+__Link:__ [https://github.com/cloudfind/kompose-docker](https://github.com/cloudfind/kompose-docker)
 
 ### KPM by CoreOS
 


### PR DESCRIPTION
The link was pointing to komposeui instead of kompose-docker