### PR TITLE
Remove redundant strings.ToLower()

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"strings"
-
 	log "github.com/Sirupsen/logrus"
 	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
@@ -46,17 +44,13 @@ var (
 	ConvertOpt                   kobject.ConvertOptions
 )
 
-// ConvertProvider TODO: comment
-var ConvertProvider = GlobalProvider
-
 var convertCmd = &cobra.Command{
 	Use:   "convert [file]",
 	Short: "Convert a Docker Compose file",
 	PreRun: func(cmd *cobra.Command, args []string) {
 
 		// Check that build-config wasn't passed in with --provider=kubernetes
-		provider := strings.ToLower(GlobalProvider)
-		if provider == "kubernetes" && UpBuild == "build-config" {
+		if GlobalProvider == "kubernetes" && UpBuild == "build-config" {
 			log.Fatalf("build-config is not a valid --build parameter with provider Kubernetes")
 		}
 
@@ -69,7 +63,7 @@ var convertCmd = &cobra.Command{
 			Replicas:                    ConvertReplicas,
 			InputFiles:                  GlobalFiles,
 			OutFile:                     ConvertOut,
-			Provider:                    strings.ToLower(GlobalProvider),
+			Provider:                    GlobalProvider,
 			CreateD:                     ConvertDeployment,
 			CreateDS:                    ConvertDaemonSet,
 			CreateRC:                    ConvertReplicationController,

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"strings"
-
 	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/spf13/cobra"
@@ -39,7 +37,7 @@ var downCmd = &cobra.Command{
 		// Create the Convert options.
 		DownOpt = kobject.ConvertOptions{
 			InputFiles:      GlobalFiles,
-			Provider:        strings.ToLower(GlobalProvider),
+			Provider:        GlobalProvider,
 			Namespace:       DownNamespace,
 			IsNamespaceFlag: cmd.Flags().Lookup("namespace").Changed,
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"strings"
 
 	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
@@ -42,8 +41,7 @@ var upCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 
 		// Check that build-config wasn't passed in with --provider=kubernetes
-		provider := strings.ToLower(GlobalProvider)
-		if provider == "kubernetes" && UpBuild == "build-config" {
+		if GlobalProvider == "kubernetes" && UpBuild == "build-config" {
 			log.Fatalf("build-config is not a valid --build parameter with provider Kubernetes")
 		}
 
@@ -52,7 +50,7 @@ var upCmd = &cobra.Command{
 			Build:              UpBuild,
 			Replicas:           UpReplicas,
 			InputFiles:         GlobalFiles,
-			Provider:           strings.ToLower(GlobalProvider),
+			Provider:           GlobalProvider,
 			EmptyVols:          UpEmptyVols,
 			Namespace:          UpNamespace,
 			InsecureRepository: UpInsecureRepo,


### PR DESCRIPTION
Removes the redundant strings.ToLower commands for GlobalProvider in
up.go, convert.go and down.go