### PR TITLE
Added `--controller` feature

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"strings"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
@@ -42,6 +44,7 @@ var (
 	ConvertInsecureRepo          bool
 	ConvertDeploymentConfig      bool
 	ConvertReplicas              int
+	ConvertController            string
 	ConvertOpt                   kobject.ConvertOptions
 )
 
@@ -78,6 +81,7 @@ var convertCmd = &cobra.Command{
 			IsDeploymentFlag:            cmd.Flags().Lookup("deployment").Changed,
 			IsDaemonSetFlag:             cmd.Flags().Lookup("daemon-set").Changed,
 			IsReplicationControllerFlag: cmd.Flags().Lookup("replication-controller").Changed,
+			Controller:                  strings.ToLower(ConvertController),
 			IsReplicaSetFlag:            cmd.Flags().Lookup("replicas").Changed,
 			IsDeploymentConfigFlag:      cmd.Flags().Lookup("deployment-config").Changed,
 		}
@@ -102,6 +106,10 @@ func init() {
 	convertCmd.Flags().BoolVar(&ConvertDaemonSet, "daemon-set", false, "Generate a Kubernetes daemonset object")
 	convertCmd.Flags().BoolVarP(&ConvertDeployment, "deployment", "d", false, "Generate a Kubernetes deployment object")
 	convertCmd.Flags().BoolVar(&ConvertReplicationController, "replication-controller", false, "Generate a Kubernetes replication controller object")
+	convertCmd.Flags().StringVar(&ConvertController, "controller", "", `Set the output controller ("deployment"|"daemonSet"|"replicationController")`)
+	convertCmd.Flags().MarkDeprecated("daemon-set", "use --controller")
+	convertCmd.Flags().MarkDeprecated("deployment", "use --controller")
+	convertCmd.Flags().MarkDeprecated("replication-controller", "use --controller")
 	convertCmd.Flags().MarkHidden("chart")
 	convertCmd.Flags().MarkHidden("daemon-set")
 	convertCmd.Flags().MarkHidden("replication-controller")
@@ -112,6 +120,7 @@ func init() {
 	convertCmd.Flags().BoolVar(&ConvertInsecureRepo, "insecure-repository", false, "Use an insecure Docker repository for OpenShift ImageStream")
 	convertCmd.Flags().StringVar(&ConvertBuildRepo, "build-repo", "", "Specify source repository for buildconfig (default remote origin)")
 	convertCmd.Flags().StringVar(&ConvertBuildBranch, "build-branch", "", "Specify repository branch to use for buildconfig (default master)")
+	convertCmd.Flags().MarkDeprecated("deployment-config", "use --controller")
 	convertCmd.Flags().MarkHidden("deployment-config")
 	convertCmd.Flags().MarkHidden("insecure-repository")
 	convertCmd.Flags().MarkHidden("build-repo")

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -51,6 +51,7 @@ type ConvertOptions struct {
 	OutFile                     string
 	Provider                    string
 	Namespace                   string
+	Controller                  string
 	IsDeploymentFlag            bool
 	IsDaemonSetFlag             bool
 	IsReplicationControllerFlag bool

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -507,14 +507,13 @@ func (k *Kubernetes) CreateKubernetesObjects(name string, service kobject.Servic
 		log.Warning("Global mode not yet supported, containers will only be replicated once throughout the cluster. DaemonSet support will be added in the future.")
 		replica = 1
 	}
-
-	if opt.CreateD {
+	if opt.CreateD || opt.Controller == "deployment" {
 		objects = append(objects, k.InitD(name, service, replica))
 	}
-	if opt.CreateDS {
+	if opt.CreateDS || opt.Controller == "daemonset" {
 		objects = append(objects, k.InitDS(name, service))
 	}
-	if opt.CreateRC {
+	if opt.CreateRC || opt.Controller == "replicationcontroller" {
 		objects = append(objects, k.InitRC(name, service, replica))
 	}
 

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -466,6 +466,23 @@ cmd="kompose convert --provider=openshift --stdout -j -f $KOMPOSE_ROOT/script/te
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/v3/output-os-template.json > /tmp/output-os.json
 convert::expect_success "kompose convert --provider=openshift --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/v3/docker-compose.yaml" "/tmp/output-os.json"
 
+####
+# Test `--controller`
+# kubernetes test (controller=deployment)
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/controller/docker-compose.yml --stdout -j --controller=deployment"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-deployment-template.json > /tmp/output-k8s.json
+convert::expect_success "kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/controller/docker-compose.yml --stdout -j --controller=deployment" "/tmp/output-k8s.json"
+
+# kubernetes test (controller=daemonset)
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/controller/docker-compose.yml --stdout -j --controller=daemonset"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-daemonset-template.json > /tmp/output-k8s.json
+convert::expect_success "kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/controller/docker-compose.yml --stdout -j --controller=daemonset" "/tmp/output-k8s.json"
+
+# kubernetes test (controller=replicationcontroller)
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/controller/docker-compose.yml --stdout -j --controller=replicationcontroller"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-rc-template.json > /tmp/output-k8s.json
+convert::expect_success "kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/controller/docker-compose.yml --stdout -j --controller=replicationcontroller" "/tmp/output-k8s.json"
+
 
 # Test the "full example" from https://raw.githubusercontent.com/aanand/compose-file/master/loader/example1.env
 

--- a/script/test/fixtures/controller/docker-compose.yml
+++ b/script/test/fixtures/controller/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "2"
+
+services:
+
+  redis-master:
+    image: gcr.io/google_containers/redis:e2e 
+    ports:
+      - "6379"
+
+  redis-slave:
+    image: gcr.io/google_samples/gb-redisslave:v1
+    ports:
+      - "6379"
+    environment:
+      - GET_HOSTS_FROM=dns
+
+  frontend:
+    image: gcr.io/google-samples/gb-frontend:v4
+    ports:
+      - "80:80"
+    environment:
+      - GET_HOSTS_FROM=dns
+    labels:
+      kompose.service.type: LoadBalancer

--- a/script/test/fixtures/controller/output-k8s-daemonset-template.json
+++ b/script/test/fixtures/controller/output-k8s-daemonset-template.json
@@ -1,0 +1,248 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "frontend"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.service.type": "LoadBalancer"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "frontend"
+        },
+        "type": "LoadBalancer"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-master"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-slave",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-slave"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-slave"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DaemonSet",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "frontend"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.service.type": "LoadBalancer"
+
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "frontend"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "frontend",
+                "image": "gcr.io/google-samples/gb-frontend:v4",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GET_HOSTS_FROM",
+                    "value": "dns"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "currentNumberScheduled": 0,
+        "numberMisscheduled": 0,
+        "desiredNumberScheduled": 0
+      }
+    },
+    {
+      "kind": "DaemonSet",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-master"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis-master",
+                "image": "gcr.io/google_containers/redis:e2e",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "currentNumberScheduled": 0,
+        "numberMisscheduled": 0,
+        "desiredNumberScheduled": 0
+      }
+    },
+    {
+      "kind": "DaemonSet",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis-slave",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-slave"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-slave"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis-slave",
+                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GET_HOSTS_FROM",
+                    "value": "dns"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "currentNumberScheduled": 0,
+        "numberMisscheduled": 0,
+        "desiredNumberScheduled": 0
+      }
+    }
+  ]
+}

--- a/script/test/fixtures/controller/output-k8s-deployment-template.json
+++ b/script/test/fixtures/controller/output-k8s-deployment-template.json
@@ -1,0 +1,242 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "frontend"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.service.type": "LoadBalancer"
+
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "frontend"
+        },
+        "type": "LoadBalancer"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-master"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-slave",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-slave"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-slave"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "frontend"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.service.type": "LoadBalancer"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "frontend"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "frontend",
+                "image": "gcr.io/google-samples/gb-frontend:v4",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GET_HOSTS_FROM",
+                    "value": "dns"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-master"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis-master",
+                "image": "gcr.io/google_containers/redis:e2e",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis-slave",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-slave"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-slave"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis-slave",
+                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GET_HOSTS_FROM",
+                    "value": "dns"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/controller/output-k8s-rc-template.json
+++ b/script/test/fixtures/controller/output-k8s-rc-template.json
@@ -1,0 +1,244 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "frontend"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.service.type": "LoadBalancer"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "frontend"
+        },
+        "type": "LoadBalancer"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-master"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-slave",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-slave"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-slave"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "frontend",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "frontend"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.service.type": "LoadBalancer"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "frontend"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "frontend",
+                "image": "gcr.io/google-samples/gb-frontend:v4",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GET_HOSTS_FROM",
+                    "value": "dns"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-master"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis-master",
+                "image": "gcr.io/google_containers/redis:e2e",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "ReplicationController",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-slave",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-slave"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-slave"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis-slave",
+                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "GET_HOSTS_FROM",
+                    "value": "dns"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "replicas": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Previously we used to mention controller type as `--deployment`,
`--replication-controller` or `--daemonset` as argument.
But now,
it will be like,

ex.

```
kompose convert --controller=daemonset
```