### PR TITLE
Fixed tmpfs with mode failure

### DIFF
--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -56,7 +56,7 @@ func TestParseHealthCheck(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(output, expected) {
-		t.Errorf("Structs are not equal, expected: %s, output: %s", expected, output)
+		t.Errorf("Structs are not equal, expected: %v, output: %v", expected, output)
 	}
 }
 

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -45,11 +45,12 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
 	//"k8s.io/kubernetes/pkg/controller/daemon"
+	"sort"
+	"strings"
+
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/labels"
-	"sort"
-	"strings"
 )
 
 // Kubernetes implements Transformer interface and represents Kubernetes transformer
@@ -351,7 +352,7 @@ func (k *Kubernetes) ConfigTmpfs(name string, service kobject.ServiceConfig) ([]
 	for index, volume := range service.TmpFs {
 		//naming volumes if multiple tmpfs are provided
 		volumeName := fmt.Sprintf("%s-tmpfs%d", name, index)
-
+		volume = strings.Split(volume, ":")[0]
 		// create a new volume mount object and append to list
 		volMount := api.VolumeMount{
 			Name:      volumeName,

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -152,7 +152,17 @@ cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-m
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/output-os-template.json > /tmp/output-os.json
 convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml convert --stdout -j" "/tmp/output-os.json" "ignoring path on the host"
 
+######
+# Tests related to docker-compose file in /script/test/fixtures/volume-mounts/tmpfs
+# kubernetes test
+cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/output-k8s-template.json > /tmp/output-k8s.json
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j" "/tmp/output-k8s.json"
 
+# openshift test
+cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/output-os-template.json > /tmp/output-os.json
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j" "/tmp/output-os.json" 
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/envvars-separators

--- a/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml
+++ b/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+services:
+
+  redis-master:
+    image: gcr.io/google_containers/redis:e2e 
+    ports:
+      - "6379"
+    tmpfs:
+      - /tmp:rw,noexec,nosuid

--- a/script/test/fixtures/volume-mounts/tmpfs/output-k8s-template.json
+++ b/script/test/fixtures/volume-mounts/tmpfs/output-k8s-template.json
@@ -1,0 +1,94 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-master"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-master"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "redis-master-tmpfs0",
+                "emptyDir": {
+                  "medium": "Memory"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "redis-master",
+                "image": "gcr.io/google_containers/redis:e2e",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "redis-master-tmpfs0",
+                    "mountPath": "/tmp"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/volume-mounts/tmpfs/output-os-template.json
+++ b/script/test/fixtures/volume-mounts/tmpfs/output-os-template.json
@@ -1,0 +1,146 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis-master"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "redis-master"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "redis-master:e2e"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "redis-master"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis-master"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "redis-master-tmpfs0",
+                "emptyDir": {
+                  "medium": "Memory"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "redis-master",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "redis-master-tmpfs0",
+                    "mountPath": "/tmp"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis-master",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis-master"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "e2e",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "gcr.io/google_containers/redis:e2e"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #807
now kompose will ignore mode of tmpfs and will pass only mount path.