### PR TITLE
Fixed `go vet`

### DIFF
--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -56,7 +56,7 @@ func TestParseHealthCheck(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(output, expected) {
-		t.Errorf("Structs are not equal, expected: %s, output: %s", expected, output)
+		t.Errorf("Structs are not equal, expected: %v, output: %v", expected, output)
 	}
 }
 


### PR DESCRIPTION
Fixes #825 (since `go vet` was failing locally while doing `make test`)