### PR TITLE
Fixed kompose build failure

### DIFF
--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -233,7 +233,7 @@ func BuildDockerImage(service kobject.ServiceConfig, name string, relativePath s
 	// Use the build struct function to build the image
 	// Build the image!
 	build := docker.Build{Client: *client}
-	err = build.BuildImage(imagePath, imageName)
+	err = build.BuildImage(imagePath, imageName, service.Dockerfile)
 
 	if err != nil {
 		return err

--- a/pkg/utils/docker/build.go
+++ b/pkg/utils/docker/build.go
@@ -38,7 +38,7 @@ BuildImage builds a Docker image via the Docker API. Takes the source directory
 and image name and then builds the appropriate image. Tarball is utilized
 in order to make building easier.
 */
-func (c *Build) BuildImage(source string, image string) error {
+func (c *Build) BuildImage(source string, image string, dockerfile string) error {
 
 	log.Infof("Building image '%s' from directory '%s'", image, path.Base(source))
 
@@ -67,6 +67,7 @@ func (c *Build) BuildImage(source string, image string) error {
 		Name:         image,
 		InputStream:  tarballSource,
 		OutputStream: outputBuffer,
+		Dockerfile:   dockerfile,
 	}
 
 	// Build it!

--- a/script/test/fixtures/buildconfig/docker-compose-dockerfile.yml
+++ b/script/test/fixtures/buildconfig/docker-compose-dockerfile.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+services:
+    foo:
+        build:
+          context: .
+          dockerfile: build/Dockerfile
+        image: docker.io/cdrage/foobar


### PR DESCRIPTION
While `local` build, kompose was not recognizing `dockerfile` key
Hence it was breaking the build as mentioned in issue #832.
This PR will fix the issue.