### PR TITLE
Fix the cpu limits and requests in generated deployment file

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -424,7 +424,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 			}
 
 			if service.CPULimit != 0 {
-				resourceLimit[api.ResourceCPU] = *resource.NewQuantity(service.CPULimit, "RandomStringForFormat")
+				resourceLimit[api.ResourceCPU] = *resource.NewMilliQuantity(service.CPULimit, resource.DecimalSI)
 			}
 
 			template.Spec.Containers[0].Resources.Limits = resourceLimit
@@ -439,7 +439,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 			}
 
 			if service.CPUReservation != 0 {
-				resourceRequests[api.ResourceCPU] = *resource.NewQuantity(service.CPUReservation, "RandomStringForFormat")
+				resourceRequests[api.ResourceCPU] = *resource.NewMilliQuantity(service.CPUReservation, resource.DecimalSI)
 			}
 
 			template.Spec.Containers[0].Resources.Requests = resourceRequests

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -171,11 +171,11 @@ func TestCreateServiceWithCPULimit(t *testing.T) {
 	// Retrieve the deployment object and test that it matches the cpu value
 	for _, obj := range objects {
 		if deploy, ok := obj.(*extensions.Deployment); ok {
-			cpuLimit, _ := deploy.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().AsInt64()
+			cpuLimit := deploy.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().MilliValue()
 			if cpuLimit != 10 {
 				t.Errorf("Expected 10 for cpu limit check, got %v", cpuLimit)
 			}
-			cpuReservation, _ := deploy.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().AsInt64()
+			cpuReservation := deploy.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue()
 			if cpuReservation != 1 {
 				t.Errorf("Expected 1 for cpu reservation check, got %v", cpuReservation)
 			}

--- a/script/test/fixtures/v3/output-k8s-full-example.json
+++ b/script/test/fixtures/v3/output-k8s-full-example.json
@@ -155,7 +155,7 @@
             ],
             "resources": {
               "limits": {
-                "cpu": "1",
+                "cpu": "1m",
                 "memory": "52428800"
               },
               "requests": {

--- a/script/test/fixtures/v3/output-memcpu-k8s.json
+++ b/script/test/fixtures/v3/output-memcpu-k8s.json
@@ -64,11 +64,11 @@
                 "image": "redis",
                 "resources": {
                   "limits": {
-                    "cpu": "10",
+                    "cpu": "10m",
                     "memory": "52428800"
                   },
                   "requests": {
-                    "cpu": "1",
+                    "cpu": "1m",
                     "memory": "20971520"
                   }
                 }

--- a/script/test/fixtures/v3/output-os-full-example.json
+++ b/script/test/fixtures/v3/output-os-full-example.json
@@ -155,7 +155,7 @@
             ],
             "resources": {
               "limits": {
-                "cpu": "1",
+                "cpu": "1m",
                 "memory": "52428800"
               },
               "requests": {


### PR DESCRIPTION
Signed-off-by: Li Yi <denverdino@gmail.com>

The source docker-compose.yml with CPU limits and reservations is as following.

```
version: '3'
services:
  mysql:
    image: mysql:5.7
    environment:
      - MYSQL_ROOT_PASSWORD=password
    deploy:
      resources:
        limits:
          cpus: "1"
        reservations:
          cpus: "0.5"
```

The generated deployment file with kompose 1.2 has incorrect format for CPU resource

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  annotations:
    kompose.cmd: kompose convert
    kompose.version: 1.2.0 (99f88ef)
  creationTimestamp: null
  labels:
    io.kompose.service: mysql
  name: mysql
spec:
  replicas: 1
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        io.kompose.service: mysql
    spec:
      containers:
      - env:
        - name: MYSQL_ROOT_PASSWORD
          value: password
        image: mysql:5.7
        name: mysql
        resources:
          limits:
            cpu: 1e3
          requests:
            cpu: "500"
      restartPolicy: Always
status: {}
```

The proper format should be

```
...
        resources:
          limits:
            cpu: "1"
          requests:
            cpu: 500m
```