### PR TITLE
Redirects not working

### DIFF
--- a/script/sync-docs.sh
+++ b/script/sync-docs.sh
@@ -65,7 +65,8 @@ for filename in *.md; do
     jekyll="---
 layout: default
 permalink: /$name/
-redirect_from: \"/docs/$name.md\"
+redirect_from: 
+  - /docs/$name.md/
 ---
 "
     echo -e "$jekyll\n$(cat $filename)" > $filename


### PR DESCRIPTION
Due to not adding a trailing `/` redirects were not working.

For example, going to kompose.io/docs/user-guide.md will appear as
plaintext html, adding a trailing / creates an index.html in the
directory and correctly redirects the user.