### PR TITLE
Fix Redirecting Error in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
 # Kompose Documentation
 
 * [Introduction](introduction.md)
-* [Quick Start](quickstart.md)
+* [Getting Started](getting-started.md)
 * [User Guide](user-guide.md)
 * [Architecture](architecture.md)
 * [Conversion](conversion.md)
 * [Development](development.md)
-* [Setup](setup.md)
+* [Installation](installation.md)


### PR DESCRIPTION
Setup and Quickstart file are giving 404 as they were renamed
to installation and getting-started repectively.
Renamed the same in README.md to fix redirecting.
Fixes #845