### PR TITLE
Updated `--help` page for `kompose up`

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -78,11 +78,46 @@ func init() {
 	upCmd.Flags().StringVar(&UpNamespace, "namespace", "default", "Specify Namespace to deploy your application")
 	upCmd.Flags().StringVar(&UpBuild, "build", "local", `Set the type of build ("local"|"build-config" (OpenShift only)|"none")`)
 	upCmd.Flags().StringVar(&UpBuildRepo, "build-repo", "", "Specify source repository for buildconfig (default remote origin)")
-
 	upCmd.Flags().StringVar(&UpBuildBranch, "build-branch", "", "Specify repository branch to use for buildconfig (default master)")
+	upCmd.Flags().MarkHidden("insecure-repository")
+	upCmd.Flags().MarkHidden("build-repo")
+	upCmd.Flags().MarkHidden("build-branch")
+
 	// Deprecated
 	upCmd.Flags().BoolVar(&UpEmptyVols, "emptyvols", false, "Use empty volumes. Do not generate PersistentVolumeClaim")
 	upCmd.Flags().MarkDeprecated("emptyvols", "emptyvols has been marked as deprecated. Use --volumes empty")
+
+	// In order to 'separate' both OpenShift and Kubernetes only flags. A custom help page is created
+	customHelp := `Usage:{{if .Runnable}}
+  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+OpenShift Flags:
+      --build-branch             Specify repository branch to use for buildconfig (default is current branch name)
+      --build-repo               Specify source repository for buildconfig (default is current branch's remote url
+      --insecure-repository      Specify to use insecure docker repository while generating Openshift image stream object
+
+Flags:
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+	// Set the help template + add the command to root
+	upCmd.SetUsageTemplate(customHelp)
 
 	RootCmd.AddCommand(upCmd)
 }


### PR DESCRIPTION
This PR will add customhelp section in `kompose up --help` section,
which will show consistency in help section.
Issue reference: #842

for example,

```
$ kompose up --help
Deploy your Dockerized application to a container orchestrator. (default "kubernetes")

Usage:
  kompose up [flags]

OpenShift Flags:
      --build-branch             Specify repository branch to use for buildconfig (default is current branch name)
      --build-repo               Specify source repository for buildconfig (default is current branch's remote url
      --insecure-repository      Specify to use insecure docker repository while generating Openshift image stream object

Flags:
      --build string       Set the type of build ("local"|"build-config" (OpenShift only)|"none") (default "local")
  -h, --help               help for up
      --namespace string   Specify Namespace to deploy your application (default "default")
      --replicas int       Specify the number of replicas generated (default 1)
      --volumes string     Volumes to be generated ("persistentVolumeClaim"|"emptyDir") (default "persistentVolumeClaim")

Global Flags:
      --error-on-warning    Treat any warning as an error
  -f, --file stringArray    Specify an alternative compose file
      --provider string     Specify a provider. Kubernetes or OpenShift. (default "kubernetes")
      --suppress-warnings   Suppress all warnings
  -v, --verbose             verbose output
```