### PR TITLE
Add TOC to documentation, add readme.md notice

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,1 @@
-# Kompose Documentation
-
-* [Introduction](introduction.md)
-* [Getting Started](getting-started.md)
-* [User Guide](user-guide.md)
-* [Architecture](architecture.md)
-* [Conversion](conversion.md)
-* [Development](development.md)
-* [Installation](installation.md)
+Note: These /docs files are best viewed at [kompose.io](http://kompose.io)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,8 @@
 # Architecture and Internal Design
 
+* TOC
+{:toc}
+
 `kompose` has 3 stages: Loader, Transformer and Outputter. Each Stage should have well defined interface so it is easy to write new Loader, Transformer or Outputters and plug it in. Currently only Loader and Transformer interfaces are defined.
 
 ![Design Diagram](/docs/images/design_diagram.png)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,7 @@
 # Getting Started
 
-- [Minikube and Kompose](#minikube-and-kompose)  
-- [Minishift and Kompose](#minishift-and-kompose)  
-- [RHEL and Kompose](#rhel-and-kompose)
+* TOC
+{:toc}
 
 This is how you'll get started with Kompose!
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,5 +1,8 @@
 # Integrations
 
+* TOC
+{:toc}
+
 There are some projects out there known to use Kompose integrated in some form or another
 
 ### Kompose UI by Jad Chamoun (ICANN) and Joe Haddad (Anghami)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,16 +1,7 @@
 # User Guide
 
-- Command Line
-  - [Kompose Convert](#kompose-convert)
-  - [Kompose Up](#kompose-up)
-  - [Kompose Down](#kompose-down)
-
-- Documentation
-  - [Build and Push Docker Images](#build-and-push-docker-images)
-  - [Alternative Conversions](#alternative-conversions)
-  - [Labels](#labels)
-  - [Restart](#restart)
-  - [Docker Compose Versions](#docker-compose-versions)
+* TOC
+{:toc}
 
 Kompose has support for two providers: OpenShift and Kubernetes.
 You can choose a targeted provider using global option `--provider`. If no provider is specified, Kubernetes is set by default.


### PR DESCRIPTION
Adds TOC to architecture.md, getting-started.md, integrations.md and
user-guide.md

Updates README.md to add a notice that the files are best viewed on the
website.