### PR TITLE
Move version information to separate file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 
 GITCOMMIT := $(shell git rev-parse --short HEAD)
-BUILD_FLAGS := -ldflags="-w -X github.com/kubernetes/kompose/cmd.GITCOMMIT=$(GITCOMMIT)"
+BUILD_FLAGS := -ldflags="-w -X github.com/kubernetes/kompose/pkg/version.GITCOMMIT=$(GITCOMMIT)"
 PKGS = $(shell glide novendor)
 TEST_IMAGE := kompose/tests:latest
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,16 +19,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/kubernetes/kompose/pkg/version"
 	"github.com/spf13/cobra"
-)
-
-var (
-	// VERSION  is version number that wil be displayed when running ./kompose version
-	VERSION = "1.4.0"
-	// GITCOMMIT is hash of the commit that wil be displayed when running ./kompose version
-	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/kubernetes/kompose/cmd.GITCOMMIT=$(GITCOMMIT)"
-	// HEAD is default indicating that this was not set during build
-	GITCOMMIT = "HEAD"
 )
 
 // versionCmd represents the version command
@@ -36,7 +28,8 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version of Kompose",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(VERSION + " (" + GITCOMMIT + ")")
+		// See pkg/version/version.go for more information as to why we use the git commit / hash value
+		fmt.Println(version.VERSION + " (" + version.GITCOMMIT + ")")
 	},
 }
 

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/kubernetes/kompose/pkg/utils/docker"
 
+	"github.com/kubernetes/kompose/pkg/version"
+
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api"
 )
@@ -117,13 +119,19 @@ func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 		annotations[key] = value
 	}
 	annotations["kompose.cmd"] = strings.Join(os.Args, " ")
-	version := exec.Command("kompose", "version")
-	out, err := version.Output()
+	versionCmd := exec.Command("kompose", "version")
+	out, err := versionCmd.Output()
 	if err != nil {
 		errors.Wrap(err, "Failed to get kompose version")
 
 	}
 	annotations["kompose.version"] = strings.Trim(string(out), " \n")
+
+	// If the version is blank (couldn't retrieve the kompose version for whatever reason)
+	if annotations["kompose.version"] == "" {
+		annotations["kompose.version"] = version.VERSION + " (" + version.GITCOMMIT + ")"
+	}
+
 	return annotations
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,10 @@
+package version
+
+var (
+	// VERSION  is version number that wil be displayed when running ./kompose version
+	VERSION = "1.4.0"
+	// GITCOMMIT is hash of the commit that wil be displayed when running ./kompose version
+	// this will be overwritten when running  build like this: go build -ldflags="-X github.com/kubernetes/kompose/pkg/version.GITCOMMIT=$(GITCOMMIT)"
+	// HEAD is default indicating that this was not set during build
+	GITCOMMIT = "HEAD"
+)

--- a/script/release.sh
+++ b/script/release.sh
@@ -91,8 +91,8 @@ init_sync() {
 }
 
 replaceversion() {
-  echo "Replaced version in version.go"
-  sed -i "s/$1/$2/g" cmd/version.go
+  echo "Replaced version in pkg/version/version.go"
+  sed -i "s/$1/$2/g" pkg/version/version.go
 
   echo "Replaced version in README.md"
   sed -i "s/$1/$2/g" README.md


### PR DESCRIPTION
Moves the version information to a seperate file. This is mostly due to
import cycle errors occuring when using "import
github.com/kubernetes/kompose/cmd" in order to get the global variable
of VERSION and GITCOMMIT.

Update's the Makefile and other files accordingly.

If the version and commmit is unretriveable due to not being able to
find the kompose binary, the one from pkg/version/version.go will be
used.