### PR TITLE
 Set PVC volume size with kompose.volume.size

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -142,4 +142,5 @@ type Volumes struct {
 	Container  string // Mountpath
 	Mode       string // access mode for volume
 	PVCName    string // name of PVC
+	PVCSize    string // PVC size
 }

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -217,7 +217,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 		LoadedFrom:     "compose",
 	}
 
-	// Step 2. Parse through the object and conver it to kobject.KomposeObject!
+	// Step 2. Parse through the object and convert it to kobject.KomposeObject!
 	// Here we "clean up" the service configuration so we return something that includes
 	// all relevant information as well as avoid the unsupported keys as well.
 	for _, composeServiceConfig := range composeObject.Services {
@@ -240,6 +240,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 		serviceConfig.ContainerName = composeServiceConfig.ContainerName
 		serviceConfig.Command = composeServiceConfig.Entrypoint
 		serviceConfig.Args = composeServiceConfig.Command
+		serviceConfig.Labels = composeServiceConfig.Labels
 
 		//
 		// Deploy keys


### PR DESCRIPTION
#235 

Example:
```
version: '3'
services:
  cs-btcd:
    image: cybernode/bitcoin-btcd:temp
    labels:
      kompose.volume.size: 500Mi
    volumes:
      - /cyberdata:/cyberdata
```