### PR TITLE
Adding `--controller` flag in `up` & `down`

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"strings"
+
 	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/spf13/cobra"
@@ -24,8 +26,9 @@ import (
 
 // TODO: comment
 var (
-	DownNamespace string
-	DownOpt       kobject.ConvertOptions
+	DownNamespace  string
+	DownController string
+	DownOpt        kobject.ConvertOptions
 )
 
 var downCmd = &cobra.Command{
@@ -39,6 +42,7 @@ var downCmd = &cobra.Command{
 			InputFiles:      GlobalFiles,
 			Provider:        GlobalProvider,
 			Namespace:       DownNamespace,
+			Controller:      strings.ToLower(DownController),
 			IsNamespaceFlag: cmd.Flags().Lookup("namespace").Changed,
 		}
 
@@ -52,5 +56,6 @@ var downCmd = &cobra.Command{
 
 func init() {
 	downCmd.Flags().StringVar(&DownNamespace, "namespace", "default", " Specify Namespace to deploy your application")
+	downCmd.Flags().StringVar(&DownController, "controller", "", `Set the output controller ("deployment"|"daemonSet"|"replicationController")`)
 	RootCmd.AddCommand(downCmd)
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubernetes/kompose/pkg/app"
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 // TODO: comment
@@ -35,6 +36,7 @@ var (
 	UpBuild        string
 	UpBuildBranch  string
 	UpBuildRepo    string
+	UpController   string
 )
 
 var upCmd = &cobra.Command{
@@ -60,6 +62,7 @@ var upCmd = &cobra.Command{
 			InsecureRepository: UpInsecureRepo,
 			BuildBranch:        UpBuildBranch,
 			BuildRepo:          UpBuildRepo,
+			Controller:         strings.ToLower(UpController),
 			IsNamespaceFlag:    cmd.Flags().Lookup("namespace").Changed,
 		}
 
@@ -79,6 +82,7 @@ func init() {
 	upCmd.Flags().StringVar(&UpBuild, "build", "local", `Set the type of build ("local"|"build-config" (OpenShift only)|"none")`)
 	upCmd.Flags().StringVar(&UpBuildRepo, "build-repo", "", "Specify source repository for buildconfig (default remote origin)")
 	upCmd.Flags().StringVar(&UpBuildBranch, "build-branch", "", "Specify repository branch to use for buildconfig (default master)")
+	upCmd.Flags().StringVar(&UpController, "controller", "", `Set the output controller ("deployment"|"daemonSet"|"replicationController")`)
 	upCmd.Flags().MarkHidden("insecure-repository")
 	upCmd.Flags().MarkHidden("build-repo")
 	upCmd.Flags().MarkHidden("build-branch")

--- a/script/test_k8s/kubernetes.sh
+++ b/script/test_k8s/kubernetes.sh
@@ -103,6 +103,19 @@ test_k8s() {
     sleep 2 # Sleep for k8s to catch up to deployment
     echo -e "\n${RED}kompose down -f $f ${NC}\n"
     ./kompose down -f $f
+    echo -e "\nTesting controller=daemonset key\n"
+    echo -e "\n${RED}kompose up -f $f --controller=daemonset ${NC}\n"
+    ./kompose up -f $f --controller=daemonset
+    sleep 2 # Sleep for k8s to catch up to deployment
+    echo -e "\n${RED}kompose down -f $f --controller=daemonset ${NC}\n"
+    ./kompose down -f $f --controller=daemonset
+    echo -e "\nTesting controller=replicationcontroller key\n"
+    echo -e "\n${RED}kompose up -f $f --controller=replicationcontroller ${NC}\n"
+    ./kompose up -f $f --controller=replicationcontroller
+    sleep 2 # Sleep for k8s to catch up to deployment
+    echo -e "\n${RED}kompose down -f $f --controller=replicationcontroller ${NC}\n"
+    ./kompose down -f $f --controller=replicationcontroller
+
   done
 }
 


### PR DESCRIPTION
To make `kompose up` & `kompose convert` equal in feature, This PR will
add `--controller` flag for `kompose up` as well as `kompose down`
so that user experience will be the same for `up` & `convert`
Resolves #798