### PR TITLE
Kompose will read input from stdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - script/test/cmd/fix_detached_head.sh
 
 script:
+  - make bin
   - make test
   # Only cross-compile once
   - if [ "$CROSS_COMPILE" == "yes" ]; then make cross; fi

--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,16 @@ clean:
 
 .PHONY: test-unit
 test-unit:
-	go test $(BUILD_FLAGS) -race -cover -v $(PKGS)
+	go test -short $(BUILD_FLAGS) -race -cover -v $(PKGS)
 
 # Run unit tests and collect coverage
 .PHONY: test-unit-cover
 test-unit-cover:
 	# First install packages that are dependencies of the test. 
-	go test -i -race -cover $(PKGS)
-	# go test doesn't support collecting coverage across multiple packages,
+	go test -short -i -race -cover $(PKGS)
+	# go test doesn't support colleting coverage across multiple packages,
 	# generate go test commands using go list and run go test for every package separately 
-	go list -f '"go test -race -cover -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kubernetes/kompose/...  | grep -v "vendor" | xargs -L 1 -P4 sh -c 
+	go list -f '"go test -short -race -cover -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kubernetes/kompose/...  | grep -v "vendor" | xargs -L 1 -P4 sh -c
 
 
 # run openshift up/down tests
@@ -94,7 +94,7 @@ check-vendor:
 
 # Run all tests
 .PHONY: test
-test: test-dep check-vendor validate test-unit-cover install test-cmd
+test: bin test-dep check-vendor validate test-unit-cover install test-cmd
 
 # Install all the required test-dependencies before executing tests (only valid when running `make test`)
 .PHONY: test-dep

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -24,6 +24,9 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"bufio"
+	"os"
+
 	"github.com/docker/libcompose/project"
 	"github.com/fatih/structs"
 	"github.com/kubernetes/kompose/pkg/kobject"
@@ -199,10 +202,16 @@ func getVersionFromFile(file string) (string, error) {
 		Version string `json:"version"` // This affects YAML as well
 	}
 	var version ComposeVersion
-
-	loadedFile, err := ioutil.ReadFile(file)
-	if err != nil {
-		return "", err
+	var loadedFile []byte
+	var err error
+	if file == "-" {
+		data := bufio.NewScanner(os.Stdin)
+		loadedFile = data.Bytes()
+	} else {
+		loadedFile, err = ioutil.ReadFile(file)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	err = yaml.Unmarshal(loadedFile, &version)

--- a/script/test/cmd/.coverprofile
+++ b/script/test/cmd/.coverprofile
@@ -1,0 +1,1 @@
+mode: atomic

--- a/script/test/cmd/cmd_test.go
+++ b/script/test/cmd/cmd_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+var ProjectPath = "$GOPATH/src/github.com/kubernetes/kompose/"
+var BinaryLocation = os.ExpandEnv(ProjectPath + "kompose")
+
+func Test_stdin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	kjson := `{"version": "2","services": {"redis": {"image": "redis:3.0","ports": ["6379"]}}}`
+	cmdStr := fmt.Sprintf("%s convert --stdout -j -f - <<EOF\n%s\nEOF\n", BinaryLocation, kjson)
+	subproc := exec.Command("/bin/sh", "-c", cmdStr)
+	output, err := subproc.Output()
+	if err != nil {
+		fmt.Println("error", err)
+	}
+	g, err := ioutil.ReadFile("/tmp/output-k8s.json")
+	if !bytes.Equal(output, g) {
+		t.Errorf("Test Failed")
+	}
+}

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -663,5 +663,12 @@ cmd="kompose convert --provider=openshift --stdout -j -f $KOMPOSE_ROOT/examples/
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/examples/output-gitlab-os.json > /tmp/output-os.json
 convert::expect_success_and_warning "kompose convert --provider=openshift --stdout -j -f $KOMPOSE_ROOT/examples/docker-gitlab.yaml" "/tmp/output-os.json"
 
+# Testing stdin feature
+cmd="$KOMPOSE_ROOT/kompose convert --stdout -j -f -"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/stdin/output.json > /tmp/output-k8s.json
+
+echo -e "\n"
+go test -v github.com/kubernetes/kompose/script/test/cmd
+
 rm /tmp/output-k8s.json /tmp/output-os.json
 exit $EXIT_STATUS

--- a/script/test/fixtures/stdin/output.json
+++ b/script/test/fixtures/stdin/output.json
@@ -1,0 +1,80 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis:3.0",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test_k8s/kubernetes.sh
+++ b/script/test_k8s/kubernetes.sh
@@ -117,6 +117,13 @@ test_k8s() {
     ./kompose down -f $f --controller=replicationcontroller
 
   done
+
+  echo -e "\nTesting stdin to kompose\n"
+  echo -e "\n${RED}cat examples/docker-compose.yaml | ./kompose up -f -${NC}\n"
+  cat examples/docker-compose.yaml | ./kompose up -f -
+  sleep 2 # Sleep for k8s to catch up to deployment
+  echo -e "\n${RED}cat examples/docker-compose.yaml | ./kompose down -f - ${NC}\n"
+  cat examples/docker-compose.yaml | ./kompose down -f -
 }
 
 if [[ $1 == "start" ]]; then


### PR DESCRIPTION
Resolves issue #870

for example,

```
$ cat docker-compose.yaml | kompose convert -f -
INFO Kubernetes file "frontend-service.yaml" created
INFO Kubernetes file "redis-master-service.yaml" created
INFO Kubernetes file "redis-slave-service.yaml" created
INFO Kubernetes file "frontend-deployment.yaml" created
INFO Kubernetes file "redis-master-deployment.yaml" created
INFO Kubernetes file "redis-slave-deployment.yaml" created
```