### PR TITLE
[RFC] Map ingress path to optional 'kompose.service.expose_path'

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -92,6 +92,7 @@ type ServiceConfig struct {
 	Build           string              `compose:"build"`
 	BuildArgs       map[string]*string  `compose:"build-args"`
 	ExposeService   string              `compose:"kompose.service.expose"`
+	ExposePath      string              `compose:"kompose.service.expose_path"`
 	Stdin           bool                `compose:"stdin_open"`
 	Tty             bool                `compose:"tty"`
 	MemLimit        yaml.MemStringorInt `compose:"mem_limit"`

--- a/pkg/loader/compose/v1v2.go
+++ b/pkg/loader/compose/v1v2.go
@@ -241,6 +241,8 @@ func libComposeToKomposeMapping(composeObject *project.Project) (kobject.Kompose
 				serviceConfig.ServiceType = serviceType
 			case "kompose.service.expose":
 				serviceConfig.ExposeService = strings.ToLower(value)
+			case "kompose.service.expose_path":
+				serviceConfig.ExposePath = value
 			}
 		}
 		err = checkLabelsPorts(len(serviceConfig.Port), composeServiceConfig.Labels["kompose.service.type"], name)

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -351,6 +351,8 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 				serviceConfig.ServiceType = serviceType
 			case "kompose.service.expose":
 				serviceConfig.ExposeService = strings.ToLower(value)
+			case "kompose.service.expose_path":
+				serviceConfig.ExposePath = value
 			}
 		}
 

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -263,6 +263,10 @@ func (k *Kubernetes) initIngress(name string, service kobject.ServiceConfig, por
 		ingress.Spec.Rules[0].Host = service.ExposeService
 	}
 
+	if service.ExposePath != "" {
+		ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Path = service.ExposePath
+	}
+
 	return ingress
 }
 


### PR DESCRIPTION
I've cobbled this together to allow a new optional label `kompose.service.expose_path` to map to `ingress.spec.rules[].http.paths[].path`.

This supports a workflow I find desirable, and I suspect others may find this useful too. I've never worked with Go before, so please forgive me if the implementation is sub-optimal. Also, I'm aware that you may not want to maintain such a specific feature, so I didn't spend any time adding tests or docs at this point.

If a maintainer here feels the concept is sound but has implementation advice, I'm more than happy to spend some time making this merge-worthy.