### PR TITLE
Added Case for Config Map in kompose down

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -177,7 +177,8 @@ func (k *Kubernetes) InitConfigMap(name string, service kobject.ServiceConfig, o
 			APIVersion: "v1",
 		},
 		ObjectMeta: api.ObjectMeta{
-			Name: name + "-" + envName,
+			Name:   name + "-" + envName,
+			Labels: transformer.ConfigLabels(name + "-" + envName),
 		},
 		Data: envs,
 	}
@@ -1064,6 +1065,24 @@ func (k *Kubernetes) Undeploy(komposeObject kobject.KomposeObject, opt kobject.C
 						break
 					}
 					log.Infof("Successfully deleted Pod: %s", t.Name)
+				}
+			}
+
+		case *api.ConfigMap:
+			// delete ConfigMap
+			configMap, err := client.ConfigMaps(namespace).List(options)
+			if err != nil {
+				errorList = append(errorList, err)
+				break
+			}
+			for _, l := range configMap.Items {
+				if reflect.DeepEqual(l.Labels, komposeLabel) {
+					err = client.ConfigMaps(namespace).Delete(t.Name)
+					if err != nil {
+						errorList = append(errorList, err)
+						break
+					}
+					log.Infof("Successfully deleted ConfigMap: %s", t.Name)
 				}
 			}
 		}

--- a/script/test/fixtures/configmap/output-k8s-template.json
+++ b/script/test/fixtures/configmap/output-k8s-template.json
@@ -113,7 +113,10 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "redis-foo-env",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+	"labels": {
+          "io.kompose.service": "redis-foo-env"
+        }
       },
       "data": {
         "ALLOW_EMPTY_PASSWORD": "yes"
@@ -124,7 +127,10 @@
       "apiVersion": "v1",
       "metadata": {
         "name": "redis-bar-env",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+	"labels": {
+          "io.kompose.service": "redis-bar-env"
+        }
       },
       "data": {
         "BAR": "FOO",


### PR DESCRIPTION
Added Case for Config Map in kompose down. To implement this, added a label in the configMap object at the time of init.
It will delete the configMap object during `kompose down`
#883 