### PR TITLE
Allow services to use same port with different protocols

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -138,6 +138,19 @@ convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/te
 
 
 ######
+# Tests related to docker-compose file in /script/test/fixtures/same-port-different-proto
+# kubernetes test
+cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/same-port-different-proto/docker-compose.yml convert --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/same-port-different-proto/output-k8s-template.json > /tmp/output-k8s.json
+convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/same-port-different-proto/docker-compose.yml convert --stdout -j" "/tmp/output-k8s.json"
+
+# openshift test
+cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/same-port-different-proto/docker-compose.yml convert --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/same-port-different-proto/output-os-template.json > /tmp/output-os.json
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/same-port-different-proto/docker-compose.yml convert --stdout -j" "/tmp/output-os.json"
+
+
+######
 # Tests related to docker-compose file in /script/test/fixtures/volume-mounts/simple-vol-mounts
 # kubernetes test
 cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml convert --stdout -j"
@@ -172,7 +185,7 @@ convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mo
 # openshift test
 cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j"
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/output-os-template.json > /tmp/output-os.json
-convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j" "/tmp/output-os.json" 
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml convert --stdout -j" "/tmp/output-os.json"
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/envvars-separators

--- a/script/test/fixtures/multiple-compose-files/output-k8s-template.json
+++ b/script/test/fixtures/multiple-compose-files/output-k8s-template.json
@@ -25,7 +25,7 @@
             "targetPort": 9001
           },
           {
-            "name": "80",
+            "name": "80-TCP",
             "port": 80,
             "targetPort": 9001
           }

--- a/script/test/fixtures/same-port-different-proto/docker-compose.yml
+++ b/script/test/fixtures/same-port-different-proto/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+services:
+    web:
+      image: tuna/docker-counter23
+      ports:
+        - "5000:5000/tcp"
+      links:
+        - redis
+      networks:
+        - default
+
+    redis:
+      image: redis:3.0
+      networks:
+        - default
+      ports:
+        - "6379/tcp"
+        - "6379/udp"
+        - "1234:1235/udp"
+

--- a/script/test/fixtures/same-port-different-proto/output-k8s-template.json
+++ b/script/test/fixtures/same-port-different-proto/output-k8s-template.json
@@ -1,0 +1,174 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
+          },
+          {
+            "name": "6379-UDP",
+            "protocol": "UDP",
+            "port": 6379,
+            "targetPort": 6379
+          },
+
+          {
+            "name": "1234",
+            "protocol": "UDP",
+            "port": 1234,
+            "targetPort": 1235
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": "redis:3.0",
+                "ports": [
+                  {
+                    "containerPort": 6379
+                  },
+                  {
+                    "containerPort": 6379,
+                    "protocol": "UDP"
+                  },
+                  {
+                    "containerPort": 1235,
+                    "protocol": "UDP"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "tuna/docker-counter23",
+                "ports": [
+                  {
+                    "containerPort": 5000
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/same-port-different-proto/output-os-template.json
+++ b/script/test/fixtures/same-port-different-proto/output-os-template.json
@@ -7,10 +7,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "etherpad",
+        "name": "redis",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "etherpad"
+          "io.kompose.service": "redis"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -20,18 +20,25 @@
       "spec": {
         "ports": [
           {
-            "name": "80",
-            "port": 80,
-            "targetPort": 9001
+            "name": "6379",
+            "port": 6379,
+            "targetPort": 6379
           },
           {
-            "name": "80-TCP",
-            "port": 80,
-            "targetPort": 9001
+            "name": "6379-UDP",
+            "protocol": "UDP",
+            "port": 6379,
+            "targetPort": 6379
+          },
+          {
+            "name": "1234",
+            "protocol": "UDP",
+            "port": 1234,
+            "targetPort": 1235
           }
         ],
         "selector": {
-          "io.kompose.service": "etherpad"
+          "io.kompose.service": "redis"
         }
       },
       "status": {
@@ -42,10 +49,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mariadb",
+        "name": "web",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "mariadb"
+          "io.kompose.service": "web"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -55,18 +62,13 @@
       "spec": {
         "ports": [
           {
-            "name": "3306",
-            "port": 3306,
-            "targetPort": 3306
-          },
-          {
-            "name": "3307",
-            "port": 3307,
-            "targetPort": 3307
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
           }
         ],
         "selector": {
-          "io.kompose.service": "mariadb"
+          "io.kompose.service": "web"
         }
       },
       "status": {
@@ -77,10 +79,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "etherpad",
+        "name": "redis",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "etherpad"
+          "io.kompose.service": "redis"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -100,11 +102,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "etherpad"
+                "redis"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "etherpad:latest"
+                "name": "redis:3.0"
               }
             }
           }
@@ -112,48 +114,31 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "etherpad"
+          "io.kompose.service": "redis"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "etherpad"
+              "io.kompose.service": "redis"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "etherpad",
+                "name": "redis",
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 9001
+                    "containerPort": 6379
                   },
                   {
-                    "containerPort": 9001
-                  }
-                ],
-                "env": [
-                  {
-                    "name": "DB_DBID",
-                    "value": "openshift"
+                    "containerPort": 6379,
+                    "protocol": "UDP"
                   },
                   {
-                    "name": "DB_HOST",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "DB_PASS",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "DB_PORT",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "DB_USER",
-                    "value": "openshift"
+                    "containerPort": 1235,
+                    "protocol": "UDP"
                   }
                 ],
                 "resources": {}
@@ -169,20 +154,20 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "etherpad",
+        "name": "redis",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "etherpad"
+          "io.kompose.service": "redis"
         }
       },
       "spec": {
         "tags": [
           {
-            "name": "latest",
+            "name": "3.0",
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "centos/etherpad"
+              "name": "redis:3.0"
             },
             "generation": null,
             "importPolicy": {}
@@ -197,10 +182,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mariadb",
+        "name": "web",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "mariadb"
+          "io.kompose.service": "web"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -209,7 +194,6 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
           "resources": {}
         },
         "triggers": [
@@ -221,11 +205,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "mariadb"
+                "web"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "mariadb:latest"
+                "name": "web:latest"
               }
             }
           }
@@ -233,71 +217,26 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "mariadb"
+          "io.kompose.service": "web"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "mariadb"
+              "io.kompose.service": "web"
             }
           },
           "spec": {
-            "volumes": [
-              {
-                "name": "mariadb-claim0",
-                "persistentVolumeClaim": {
-                  "claimName": "mariadb-claim0"
-                }
-              },
-              {
-                "name": "mariadb-claim1",
-                "persistentVolumeClaim": {
-                  "claimName": "mariadb-claim1"
-                }
-              }
-            ],
             "containers": [
               {
-                "name": "mariadb",
+                "name": "web",
                 "image": " ",
                 "ports": [
                   {
-                    "containerPort": 3306
-                  },
-                  {
-                    "containerPort": 3307
+                    "containerPort": 5000
                   }
                 ],
-                "env": [
-                  {
-                    "name": "MYSQL_DATABASE",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "MYSQL_PASSWORD",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "MYSQL_ROOT_PASSWORD",
-                    "value": "openshift"
-                  },
-                  {
-                    "name": "MYSQL_USER",
-                    "value": "openshift"
-                  }
-                ],
-                "resources": {},
-                "volumeMounts": [
-                  {
-                    "name": "mariadb-claim0",
-                    "mountPath": "/var/lib/mysql"
-                  },
-                  {
-                    "name": "mariadb-claim1",
-                    "mountPath": "/var/lib/mysql"
-                  }
-                ]
+                "resources": {}
               }
             ],
             "restartPolicy": "Always"
@@ -310,10 +249,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mariadb",
+        "name": "web",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "mariadb"
+          "io.kompose.service": "web"
         }
       },
       "spec": {
@@ -323,7 +262,7 @@
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "centos/mariadb"
+              "name": "tuna/docker-counter23"
             },
             "generation": null,
             "importPolicy": {}
@@ -333,50 +272,6 @@
       "status": {
         "dockerImageRepository": ""
       }
-    },
-    {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "mariadb-claim0",
-        "creationTimestamp": null,
-        "labels": {
-          "io.kompose.service": "mariadb-claim0"
-        }
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "100Mi"
-          }
-        }
-      },
-      "status": {}
-    },
-    {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "mariadb-claim1",
-        "creationTimestamp": null,
-        "labels": {
-          "io.kompose.service": "mariadb-claim1"
-        }
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "100Mi"
-          }
-        }
-      },
-      "status": {}
     }
   ]
 }


### PR DESCRIPTION
kompose fails if compose file declares different protocols for the same port. eg;

```
...
     ports:
      - 666:666/udp
      - 666:666/tcp
...
```

This PR adds the port to the output and also makes sure that names are unique for each port/protocol pair. This is supported with LoadBalancer (https://github.com/kubernetes/kubernetes/issues/2995
) so trying to use this config with LB panics