### PR TITLE
Remove unneeded todo comment

### DIFF
--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -71,7 +71,6 @@ func loadEnvVars(envars []string) []kobject.EnvVar {
 
 // getComposeFileDir returns compose file directory
 // Assume all the docker-compose files are in the same directory
-// TODO: fix (check if file exists)
 func getComposeFileDir(inputFiles []string) (string, error) {
 	inputFile := inputFiles[0]
 	if strings.Index(inputFile, "/") != 0 {


### PR DESCRIPTION
Because when we check the version of the compose file, we have already read the file's content and ensure the file exist