### PR TITLE
Fix custom output and charts conflict error

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -362,6 +362,10 @@ convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixture
 # Behavior with -o <dirname>/<filename>
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_file -j" "$TEMP_DIR/output_file"
 
+######
+# Test charts generate with custom dir
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR -j -c" "$TEMP_DIR/Chart.yaml" "$TEMP_DIR/README.md" "$TEMP_DIR/templates/redis-deployment.json" "$TEMP_DIR/templates/redis-service.json" "$TEMP_DIR/templates/web-deployment.json" "$TEMP_DIR/templates/web-service.json"
+
 ####
 # Test regarding build context (running kompose from various directories)
 # Replacing variables with current branch and uri


### PR DESCRIPTION
fix #886 

@cdrage I didn't find a correct way to add test for  this change. So can you help me with this?

After this change, the logic now becomes:

assume there is a yaml in /tmp/a.yaml

* -c : results in /tmp/a/
* -c -o /tmp/charts : results in /tmp/charts/ (yaml in /tmp/charts/templates)
* -o /tmp/charts: results in /tmp/charts 
*  no args: results yaml in current dir

