### PR TITLE
Accept nested path such as "build: ./foo/bar" in kompose up

### DIFF
--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -217,12 +217,7 @@ func BuildDockerImage(service kobject.ServiceConfig, name string, relativePath s
 	}
 
 	// Get the appropriate image source and name
-	// use path.Base to get the last element of the relative build path
-	imagePath := path.Join(relativePath, path.Base(service.Build))
-	imageName := name
-	if service.Image != "" {
-		imageName = service.Image
-	}
+	imagePath, imageName := resolveImagePathAndName(service, name, relativePath)
 
 	// Connect to the Docker client
 	client, err := docker.DockerClient()
@@ -240,6 +235,16 @@ func BuildDockerImage(service kobject.ServiceConfig, name string, relativePath s
 	}
 
 	return nil
+}
+
+func resolveImagePathAndName(service kobject.ServiceConfig, name string, relativePath string) (string, string) {
+	imagePath := path.Join(relativePath, service.Build)
+	imageName := name
+	if service.Image != "" {
+		imageName = service.Image
+	}
+
+	return imagePath, imageName
 }
 
 // PushDockerImage pushes docker image

--- a/pkg/transformer/utils_test.go
+++ b/pkg/transformer/utils_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/kubernetes/kompose/pkg/kobject"
 )
 
 func TestFormatProviderName(t *testing.T) {
@@ -147,5 +149,41 @@ func TestGetComposeFileDir(t *testing.T) {
 	}
 	if !strings.Contains(output, "foobar") {
 		t.Errorf("Expected $PWD/foobar, got %v", output)
+	}
+}
+
+func TestResolveImagePathAndName(t *testing.T) {
+	service := kobject.ServiceConfig{}
+
+	service.Build = "."
+	service.Image = ""
+	imagePath, imageName := resolveImagePathAndName(service, "name", "/foo")
+	if imagePath != "/foo" {
+		t.Errorf("Got %s as imagePath, expected /foo", imagePath)
+	}
+	if imageName != "name" {
+		t.Errorf("Got %s as imageName, expected name", imageName)
+	}
+
+	service.Build = "./bar"
+	service.Image = "image"
+	imagePath, imageName = resolveImagePathAndName(service, "name", "/foo")
+	if imagePath != "/foo/bar" {
+		t.Errorf("Got %s as imagePath, expected /foo/bar", imagePath)
+	}
+	if imageName != "image" {
+		t.Errorf("Got %s as imageName, expected image", imageName)
+	}
+
+	service.Build = "bar"
+	imagePath, imageName = resolveImagePathAndName(service, "name", "/foo")
+	if imagePath != "/foo/bar" {
+		t.Errorf("Got %s as imagePath, expected /foo/bar", imagePath)
+	}
+
+	service.Build = "bar/buz"
+	imagePath, imageName = resolveImagePathAndName(service, "name", "/foo")
+	if imagePath != "/foo/bar/buz" {
+		t.Errorf("Got %s as imagePath, expected /foo/bar/buz", imagePath)
 	}
 }


### PR DESCRIPTION
In `kompose up`, building docker image but throws "Cannot locate specified Dockerfile" because `path.Base` removes parent directory path segments. I think that a nested path should be accepted.

For instance, in the case of #809, "./package/business_api" is modified to "business_api" by `path.Base`. However `os.Stat` verifies the existence of `service.Build` before the lines.

It's difficult to test `BuildDockerImage`, so I extracted `resolveImagePathAndName` from the func then modify it and add testing.

I have no idea why using `path.Base`. If having some reasons to make a sense, could you please write it as a comment? I will accept any reason and you can close this anytime. Thanks!