### PR TITLE
Remove bintray instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,29 +71,6 @@ source <(kompose completion zsh)
 
 ## Development and building of Kompose
 
-
-### Downloading the latest (master) binary
-
-"Nightly" binaries are generated on a per-merge basis and uploaded to [Bintray](https://bintray.com/kompose)
-
-__Linux and macOS:__
-
-```sh
-# Linux 
-curl -L https://dl.bintray.com/kompose/kompose/latest/kompose-linux-amd64 -o kompose
-
-# macOS
-curl -L https://dl.bintray.com/kompose/kompose/latest/kompose-darwin-amd64 -o kompose
-
-chmod +x kompose
-sudo mv ./kompose /usr/local/bin/kompose
-```
-
-__Windows:__
-
-Download from [Bintray](https://dl.bintray.com/kompose/kompose/latest/kompose-windows-amd64.exe) and add the binary to your PATH.
-
-
 ### Building with `go`
 __Requisites:__
 1. [make](https://www.gnu.org/software/make/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,29 +23,6 @@ __Windows:__
 
 Download from [GitHub](https://github.com/kubernetes/kompose/releases/download/v1.9.0/kompose-windows-amd64.exe) and add the binary to your PATH.
 
-
-#### Nightly / master release
-
-"Nightly" binaries are generated on a per-merge basis and uploaded to [Bintray](https://bintray.com/kompose)
-
-__Linux and macOS:__
-
-```sh
-# Linux 
-curl -L https://dl.bintray.com/kompose/kompose/latest/kompose-linux-amd64 -o kompose
-
-# macOS
-curl -L https://dl.bintray.com/kompose/kompose/latest/kompose-darwin-amd64 -o kompose
-
-chmod +x kompose
-sudo mv ./kompose /usr/local/bin/kompose
-```
-
-__Windows:__
-
-Download from [Bintray](https://dl.bintray.com/kompose/kompose/latest/kompose-windows-amd64.exe) and add the binary to your PATH.
-
-
 #### Go
 
 Installing using `go get` pulls from the master branch with the latest development changes.


### PR DESCRIPTION
Bintray forced us into an "enterprise" plan and then cut access off
unless we contacted supported.

For now, we are removing bintray details until we have a good
alternative.