### PR TITLE
Fix missing attribute when convert with multiple docker-compose files

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -122,7 +122,23 @@ cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/mem-limit/docker-compose-mb.y
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/mem-limit/output-mb-k8s-template.json > /tmp/output-k8s.json
 convert::expect_success "$cmd" "/tmp/output-k8s.json"
 
+######
+# Tests merge multiple docker-compose files
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/base.yml -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/dev.yml --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/output-base-template.json > /tmp/output-k8s.json
+convert::expect_success "$cmd" "/tmp/output-k8s.json"
 
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/compose-port-base.yml -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/compose-port-prod.yml --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json > /tmp/output-k8s.json
+convert::expect_success "$cmd" "/tmp/output-k8s.json"
+
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/compose-port-base.yml -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/compose-new-service-prob.yml --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json > /tmp/output-k8s.json
+convert::expect_success "$cmd" "/tmp/output-k8s.json"
+
+cmd="kompose --provider=openshift convert -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/compose-port-base.yml -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/compose-new-service-prob.yml --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/output-openshift-template.json > /tmp/output-os.json
+convert::expect_success "$cmd" "/tmp/output-os.json"
 
 ######
 # Tests related to docker-compose file in /script/test/fixtures/ports-with-proto

--- a/script/test/fixtures/merge-multiple-compose/base.yml
+++ b/script/test/fixtures/merge-multiple-compose/base.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  web:
+    image: richarvey/nginx-php-fpm
+    environment:
+      - ERRORS=0
+      - HIDE_NGINX_HEADERS=0
+      - REMOVE_FILES=0
+      - RUN_SCRIPTS=0
+      - PHP_ERRORS_STDERR=0
+      - ENABLE_XDEBUG=0

--- a/script/test/fixtures/merge-multiple-compose/compose-new-service-prob.yml
+++ b/script/test/fixtures/merge-multiple-compose/compose-new-service-prob.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  server:
+    ports:
+      - 5000:5000
+  new-my-service:
+    image: nginx

--- a/script/test/fixtures/merge-multiple-compose/compose-port-base.yml
+++ b/script/test/fixtures/merge-multiple-compose/compose-port-base.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  server:
+    image: test
+    container_name: test_server
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    ports:
+      - 3000:3000

--- a/script/test/fixtures/merge-multiple-compose/compose-port-prod.yml
+++ b/script/test/fixtures/merge-multiple-compose/compose-port-prod.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+services:
+  server:
+    ports:
+      - 5000:5000

--- a/script/test/fixtures/merge-multiple-compose/dev.yml
+++ b/script/test/fixtures/merge-multiple-compose/dev.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  web:
+    environment:
+      - ERRORS=1
+      - HIDE_NGINX_HEADERS=0
+      - REMOVE_FILES=0
+      - RUN_SCRIPTS=1
+      - PHP_ERRORS_STDERR=1
+      - ENABLE_XDEBUG=1

--- a/script/test/fixtures/merge-multiple-compose/output-base-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-base-template.json
@@ -1,0 +1,71 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "richarvey/nginx-php-fpm",
+                "env": [
+                  {
+                    "name": "ENABLE_XDEBUG",
+                    "value": "1"
+                  },
+                  {
+                    "name": "ERRORS",
+                    "value": "1"
+                  },
+                  {
+                    "name": "HIDE_NGINX_HEADERS",
+                    "value": "0"
+                  },
+                  {
+                    "name": "PHP_ERRORS_STDERR",
+                    "value": "1"
+                  },
+                  {
+                    "name": "REMOVE_FILES",
+                    "value": "0"
+                  },
+                  {
+                    "name": "RUN_SCRIPTS",
+                    "value": "1"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json
@@ -1,0 +1,118 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "server"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "new-my-service",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "new-my-service"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "new-my-service"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "new-my-service",
+                "image": "nginx",
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "server"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "test_server",
+                "image": "test",
+                "ports": [
+                  {
+                    "containerPort": 5000
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json
@@ -1,0 +1,80 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "server"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "server"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "test_server",
+                "image": "test",
+                "ports": [
+                  {
+                    "containerPort": 5000
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/merge-multiple-compose/output-openshift-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-openshift-template.json
@@ -1,0 +1,222 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "server"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "new-my-service",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "new-my-service"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "new-my-service"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "new-my-service:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "new-my-service"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "new-my-service"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "new-my-service",
+                "image": " ",
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "new-my-service",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "new-my-service"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "nginx"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "test_server"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "server:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "server"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "server"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "test_server",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 5000
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "test"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fix issue #972 and #968

A brief introdction:
- When multiple docker compose files are passed, we should parse every compose file and override previous object if next compose file has this field
- Docker compose merge multiple file, so we should do so
- This function is very useful
- First, I implemented the v3 compose version. Please @cdrage @hangyan help me review. If you guys accept this method, I will do the same thing to v2 compose version.

Thanks .

Signed-off-by: xianlubird <xianlubird@gmail.com>