### PR TITLE
Fix golint warnings

### DIFF
--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -34,7 +34,7 @@ const (
 	// LabelServiceExposeTLSSecret  provides the name of the TLS secret to use with the Kubernetes ingress controller
 	LabelServiceExposeTLSSecret = "kompose.service.expose.tls-secret"
 
-	// ServiceTypeHeadless...
+	// ServiceTypeHeadless ...
 	ServiceTypeHeadless = "Headless"
 )
 


### PR DESCRIPTION
Fix golint warning

```
golint ./cmd/... ./build/... ./pkg/... .
pkg/loader/compose/utils.go:37:2: comment on exported const ServiceTypeHeadless should be of the form "ServiceTypeHeadless ..."
```

Pls @cdrage @hangyan help review. Thanks