### PR TITLE
Correct the proper nouns to be in capital letter

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ type ServiceConfig struct {
 
 ## Transformer
 
-Transformer takes KomposeObject and converts it to target/output format (at this moment, there are sets of kubernetes/openshift objects). Similar to `Loader`, Transformer is represented by a Transformer interface:
+Transformer takes KomposeObject and converts it to target/output format (at this moment, there are sets of Kubernetes/OpenShift objects). Similar to `Loader`, Transformer is represented by a Transformer interface:
 
 ```go
 type Transformer interface {
@@ -71,7 +71,7 @@ type Transformer interface {
 }
 ```
 
-If you wish to add more providers which contain different kind of objects, transformer would be the place to look into. At this moment Kompose supports Kubernetes (by default) and Openshift providers. More details at:
+If you wish to add more providers which contain different kind of objects, Transformer would be the place to look into. At this moment Kompose supports Kubernetes (by default) and Openshift providers. More details at:
 
 * [kompose/pkg/transformer](https://github.com/kubernetes/kompose/tree/master/pkg/transformer)
 * [kompose/pkg/transformer/kubernetes](https://github.com/kubernetes/kompose/tree/master/pkg/transformer/kubernetes)


### PR DESCRIPTION
The proper nouns like: Kubernetes, OpenShift, Transformer should be in capital letters, while there some places in the doc use lowercases.