### PR TITLE
Remove go1.6 support in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ go_import_path: github.com/kubernetes/kompose
 
 matrix:
   include:
-    - go: 1.6
+    - go: 1.7
       env: 
         # Only build docs once
         - BUILD_DOCS=yes
         # Test cross-compile as well
         - CROSS_COMPILE=yes
-    - go: 1.7
     - go: 1.8
+    - go: 1.9
 
 install:
   - true


### PR DESCRIPTION
From the error logs of the build, the root cause is that golint have abandon the support for 1.6, and because golang already have version1.9/1.10, I think we can do that too.

https://travis-ci.org/kubernetes/kompose/jobs/373755156
@cdrage 