### PR TITLE
Add label 'kompose.controller.type' set service convert controller type

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -301,6 +301,7 @@ The currently supported options are:
 | kompose.service.expose | true / hostname |
 | kompose.service.expose.tls-secret | secret name |
 | kompose.volume.size | kubernetes supported volume size |
+| kompose.controller.type | deployment / daemonset / replicationcontroller |
 
 **Note**: `kompose.service.type` label should be defined with `ports` only (except for headless service), otherwise `kompose` will fail.
 
@@ -364,6 +365,39 @@ services:
       - db-data:/var/lib/postgresql/data
 ```
 
+- `kompose.controller.type` defines which controller type should convert for this service
+
+For example:
+
+```
+web:
+  image: wordpress:4.5
+  ports:
+    - '80'
+  environment:
+    WORDPRESS_AUTH_KEY: changeme
+    WORDPRESS_SECURE_AUTH_KEY: changeme
+    WORDPRESS_LOGGED_IN_KEY: changeme
+    WORDPRESS_NONCE_KEY: changeme
+    WORDPRESS_AUTH_SALT: changeme
+    WORDPRESS_SECURE_AUTH_SALT: changeme
+    WORDPRESS_LOGGED_IN_SALT: changeme
+    WORDPRESS_NONCE_SALT: changeme
+    WORDPRESS_NONCE_AA: changeme
+  restart: always
+  links:
+    - 'db:mysql'
+db:
+  image: mysql:5.7
+  environment:
+    MYSQL_ROOT_PASSWORD: password
+  restart: always
+  labels:
+    project.logs: /var/log/mysql
+    kompose.controller.type: daemonset
+```
+
+Service `web` will be converted to `Deployment` as default, service `db` will be converted to `DaemonSet` because of `kompose.controller.type` label.
 
 ## Restart
 

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -33,6 +33,8 @@ const (
 	LabelServiceExpose = "kompose.service.expose"
 	// LabelServiceExposeTLSSecret  provides the name of the TLS secret to use with the Kubernetes ingress controller
 	LabelServiceExposeTLSSecret = "kompose.service.expose.tls-secret"
+	// LabelControllerType defines the type of controller to be created
+	LabelControllerType = "kompose.controller.type"
 
 	// ServiceTypeHeadless ...
 	ServiceTypeHeadless = "Headless"

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -741,5 +741,22 @@ cmd="kompose convert --controller deployment --stdout -j -f $KOMPOSE_ROOT/script
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-global-deployment-template.json > /tmp/output-k8s.json
 convert::expect_success_and_warning "$cmd" "/tmp/output-k8s.json"
 
+## Test label kompose.controller.type
+cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/controller/compose-controller-label.yml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-controller-template.json > /tmp/output-k8s.json
+convert::expect_success_and_warning "$cmd" "/tmp/output-k8s.json"
+
+cmd="kompose convert --controller deployment --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/controller/compose-controller-label.yml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-controller-template.json > /tmp/output-k8s.json
+convert::expect_success_and_warning "$cmd" "/tmp/output-k8s.json"
+
+cmd="kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/controller/compose-controller-label-v3.yml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-k8s-controller-v3-template.json > /tmp/output-k8s.json
+convert::expect_success "$cmd" "/tmp/output-k8s.json"
+
+cmd="kompose --provider=openshift convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/controller/compose-controller-label-v3.yml"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/controller/output-os-controller-v3-template.json > /tmp/output-os.json
+convert::expect_success "$cmd" "/tmp/output-os.json"
+
 rm /tmp/output-k8s.json /tmp/output-os.json
 exit $EXIT_STATUS

--- a/script/test/fixtures/controller/compose-controller-label-v3.yml
+++ b/script/test/fixtures/controller/compose-controller-label-v3.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  web:
+    image: wordpress:4
+    environment:
+      - WORDPRESS_DB_PASSWORD=password
+      - WORDPRESS_AUTH_KEY=changeme
+      - WORDPRESS_SECURE_AUTH_KEY=changeme
+      - WORDPRESS_LOGGED_IN_KEY=changeme
+      - WORDPRESS_NONCE_KEY=changeme
+      - WORDPRESS_AUTH_SALT=changeme
+      - WORDPRESS_SECURE_AUTH_SALT=changeme
+      - WORDPRESS_LOGGED_IN_SALT=changeme
+      - WORDPRESS_NONCE_SALT=changeme
+      - WORDPRESS_NONCE_AA=changeme
+    ports:
+      - 80
+    depends_on:
+      - mysql
+    deploy:
+      replicas: 3
+    labels:
+      port: wordpress
+  mysql:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+    labels:
+      kompose.controller.type: daemonset

--- a/script/test/fixtures/controller/compose-controller-label.yml
+++ b/script/test/fixtures/controller/compose-controller-label.yml
@@ -1,0 +1,25 @@
+web:
+  image: wordpress:4.5
+  ports:
+    - '80'
+  environment:
+    WORDPRESS_AUTH_KEY: changeme
+    WORDPRESS_SECURE_AUTH_KEY: changeme
+    WORDPRESS_LOGGED_IN_KEY: changeme
+    WORDPRESS_NONCE_KEY: changeme
+    WORDPRESS_AUTH_SALT: changeme
+    WORDPRESS_SECURE_AUTH_SALT: changeme
+    WORDPRESS_LOGGED_IN_SALT: changeme
+    WORDPRESS_NONCE_SALT: changeme
+    WORDPRESS_NONCE_AA: changeme
+  restart: always
+  links:
+    - 'db:mysql'
+db:
+  image: mysql:5.7
+  environment:
+    MYSQL_ROOT_PASSWORD: password
+  restart: always
+  labels:
+    project.logs: /var/log/mysql
+    kompose.controller.type: daemonset

--- a/script/test/fixtures/controller/output-k8s-controller-template.json
+++ b/script/test/fixtures/controller/output-k8s-controller-template.json
@@ -1,0 +1,166 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DaemonSet",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.controller.type": "daemonset",
+          "project.logs": "/var/log/mysql"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "db"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "db",
+                "image": "mysql:5.7",
+                "env": [
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "password"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "currentNumberScheduled": 0,
+        "numberMisscheduled": 0,
+        "desiredNumberScheduled": 0
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "wordpress:4.5",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "WORDPRESS_AUTH_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_AUTH_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_LOGGED_IN_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_LOGGED_IN_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_AA",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_SECURE_AUTH_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_SECURE_AUTH_SALT",
+                    "value": "changeme"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/controller/output-k8s-controller-v3-template.json
+++ b/script/test/fixtures/controller/output-k8s-controller-v3-template.json
@@ -1,0 +1,171 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "port": "wordpress"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DaemonSet",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "mysql",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mysql"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.controller.type": "daemonset"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "mysql"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "mysql",
+                "image": "mysql:5.7",
+                "env": [
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "password"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "currentNumberScheduled": 0,
+        "numberMisscheduled": 0,
+        "desiredNumberScheduled": 0
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "port": "wordpress"
+        }
+      },
+      "spec": {
+        "replicas": 3,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": "wordpress:4",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "WORDPRESS_AUTH_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_AUTH_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_PASSWORD",
+                    "value": "password"
+                  },
+                  {
+                    "name": "WORDPRESS_LOGGED_IN_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_LOGGED_IN_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_AA",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_SECURE_AUTH_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_SECURE_AUTH_SALT",
+                    "value": "changeme"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/controller/output-os-controller-v3-template.json
+++ b/script/test/fixtures/controller/output-os-controller-v3-template.json
@@ -1,0 +1,320 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "port": "wordpress"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "80",
+            "port": 80,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DaemonSet",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "mysql",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mysql"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.controller.type": "daemonset",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "mysql"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "mysql",
+                "image": "mysql:5.7",
+                "env": [
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "password"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "currentNumberScheduled": 0,
+        "numberMisscheduled": 0,
+        "desiredNumberScheduled": 0
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mysql"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.controller.type": "daemonset",
+          "kompose.version": "%VERSION%"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "mysql"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "mysql:5.7"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "mysql"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "mysql"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "mysql",
+                "image": " ",
+                "env": [
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "password"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "mysql"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "5.7",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "mysql:5.7"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "port": "wordpress"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "web"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "web:4"
+              }
+            }
+          }
+        ],
+        "replicas": 3,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "web"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "web",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "WORDPRESS_AUTH_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_AUTH_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_PASSWORD",
+                    "value": "password"
+                  },
+                  {
+                    "name": "WORDPRESS_LOGGED_IN_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_LOGGED_IN_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_AA",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_NONCE_SALT",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_SECURE_AUTH_KEY",
+                    "value": "changeme"
+                  },
+                  {
+                    "name": "WORDPRESS_SECURE_AUTH_SALT",
+                    "value": "changeme"
+                  }
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "4",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "wordpress:4"
+            },
+            "generation": null,
+            "importPolicy": {}
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
A standard wordpress compose like this
```
web:
  image: wordpress:4.5
  ports:
    - '80'
  environment:
    WORDPRESS_AUTH_KEY: changeme
    WORDPRESS_SECURE_AUTH_KEY: changeme
    WORDPRESS_LOGGED_IN_KEY: changeme
    WORDPRESS_NONCE_KEY: changeme
    WORDPRESS_AUTH_SALT: changeme
    WORDPRESS_SECURE_AUTH_SALT: changeme
    WORDPRESS_LOGGED_IN_SALT: changeme
    WORDPRESS_NONCE_SALT: changeme
    WORDPRESS_NONCE_AA: changeme
  restart: always
  links:
    - 'db:mysql'
db:
  image: mysql:5.7
  environment:
    MYSQL_ROOT_PASSWORD: password
  restart: always
  labels:
    project.logs: /var/log/mysql
```

For service `db`, we'd better convert it to `StatefulSet`. But if we run command `kompose convert -f `, all of them are converted to `Deployment`. We have to split them into two compose file.So we'd better support a label which can control what type you want to convert.

After that, a compose like this
```
web:
  image: wordpress:4.5
  ports:
    - '80'
  environment:
    WORDPRESS_AUTH_KEY: changeme
    WORDPRESS_SECURE_AUTH_KEY: changeme
    WORDPRESS_LOGGED_IN_KEY: changeme
    WORDPRESS_NONCE_KEY: changeme
    WORDPRESS_AUTH_SALT: changeme
    WORDPRESS_SECURE_AUTH_SALT: changeme
    WORDPRESS_LOGGED_IN_SALT: changeme
    WORDPRESS_NONCE_SALT: changeme
    WORDPRESS_NONCE_AA: changeme
  restart: always
  links:
    - 'db:mysql'
db:
  image: mysql:5.7
  environment:
    MYSQL_ROOT_PASSWORD: password
  restart: always
  labels:
    project.logs: /var/log/mysql
    kompose.controller.type: daemonset
```
So service web convert to `Deployment`, service db convert to `StatefulSet`, it's very useful.


What's your opinion, @cdrage @hangyan 