### PR TITLE
Fix invalid port name with uppercase characters

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -367,7 +367,7 @@ func (k *Kubernetes) ConfigServicePorts(name string, service kobject.ServiceConf
 			if service.ServiceType == string(api.ServiceTypeLoadBalancer) {
 				log.Fatalf("Service %s of type LoadBalancer cannot use TCP and UDP for the same port", name)
 			}
-			name = fmt.Sprintf("%s-%s", name, port.Protocol)
+			name = fmt.Sprintf("%s-%s", name, strings.ToLower(string(port.Protocol)))
 		}
 
 		servicePort = api.ServicePort{

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"strings"
 )
 
 func newServiceConfig() kobject.ServiceConfig {
@@ -36,7 +37,7 @@ func newServiceConfig() kobject.ServiceConfig {
 		ContainerName: "name",
 		Image:         "image",
 		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
-		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456}},
+		Port:          []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456}, kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: api.ProtocolUDP}},
 		Command:       []string{"cmd"},
 		WorkingDir:    "dir",
 		Args:          []string{"arg1", "arg2"},
@@ -188,6 +189,13 @@ func privilegedNilOrFalse(template api.PodTemplateSpec) bool {
 func checkService(config kobject.ServiceConfig, svc *api.Service, expectedLabels map[string]string) error {
 	if !equalStringMaps(expectedLabels, svc.Spec.Selector) {
 		return fmt.Errorf("Found unexpected selector: %#v vs. %#v", expectedLabels, svc.Spec.Selector)
+	}
+	for _, port := range svc.Spec.Ports {
+		name := port.Name
+		expectedName := strings.ToLower(name)
+		if expectedName != name {
+			return fmt.Errorf("Found unexpected port name: %#v vs. %#v", expectedName, name)
+		}
 	}
 	// TODO: finish this
 	return nil

--- a/script/test/fixtures/multiple-compose-files/output-k8s-template.json
+++ b/script/test/fixtures/multiple-compose-files/output-k8s-template.json
@@ -25,7 +25,7 @@
             "targetPort": 9001
           },
           {
-            "name": "80-TCP",
+            "name": "80-tcp",
             "port": 80,
             "targetPort": 9001
           }

--- a/script/test/fixtures/multiple-compose-files/output-os-template.json
+++ b/script/test/fixtures/multiple-compose-files/output-os-template.json
@@ -25,7 +25,7 @@
             "targetPort": 9001
           },
           {
-            "name": "80-TCP",
+            "name": "80-tcp",
             "port": 80,
             "targetPort": 9001
           }

--- a/script/test/fixtures/same-port-different-proto/output-k8s-template.json
+++ b/script/test/fixtures/same-port-different-proto/output-k8s-template.json
@@ -25,7 +25,7 @@
             "targetPort": 6379
           },
           {
-            "name": "6379-UDP",
+            "name": "6379-udp",
             "protocol": "UDP",
             "port": 6379,
             "targetPort": 6379

--- a/script/test/fixtures/same-port-different-proto/output-os-template.json
+++ b/script/test/fixtures/same-port-different-proto/output-os-template.json
@@ -25,7 +25,7 @@
             "targetPort": 6379
           },
           {
-            "name": "6379-UDP",
+            "name": "6379-udp",
             "protocol": "UDP",
             "port": 6379,
             "targetPort": 6379

--- a/script/test/fixtures/v3/output-k8s-full-example.json
+++ b/script/test/fixtures/v3/output-k8s-full-example.json
@@ -28,7 +28,7 @@
             "targetPort": 3000
           },
           {
-            "name": "3000-TCP",
+            "name": "3000-tcp",
             "port": 3000,
             "targetPort": 3000
           },

--- a/script/test/fixtures/v3/output-os-full-example.json
+++ b/script/test/fixtures/v3/output-os-full-example.json
@@ -28,7 +28,7 @@
             "targetPort": 3000
           },
           {
-            "name": "3000-TCP",
+            "name": "3000-tcp",
             "port": 3000,
             "targetPort": 3000
           },


### PR DESCRIPTION
When there are multiple protocol for one port, the generated port name is invalid which has uppercase chars

E.g. 

```
version: '2'
services:
  bootstrap:
    image: test
    ports:
      - "1234:1234"
      - "1234:1234/udp"
```

The generated service config is as following

```
apiVersion: v1
kind: Service
metadata:
  annotations:
    kompose.version: 1.13.0 (84fa826)
  creationTimestamp: null
  labels:
    io.kompose.service: bootstrap
  name: bootstrap
spec:
  ports:
  - name: "1234"
    port: 1234
    targetPort: 1234
  - name: 1234-UDP
    port: 1234
    protocol: UDP
    targetPort: 1234
  selector:
    io.kompose.service: bootstrap
```

The following exception will be return when creating service

The Service "bootstrap" is invalid: spec.ports[1].name: Invalid value: "1234-UDP": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')

We should append the lower case of protocol as part of the port name.

Thanks