### PR TITLE
Remove short from testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,16 @@ clean:
 
 .PHONY: test-unit
 test-unit:
-	go test -short $(BUILD_FLAGS) -race -cover -v $(PKGS)
+	go test $(BUILD_FLAGS) -race -cover -v $(PKGS)
 
 # Run unit tests and collect coverage
 .PHONY: test-unit-cover
 test-unit-cover:
 	# First install packages that are dependencies of the test. 
-	go test -short -i -race -cover $(PKGS)
+	go test -i -race -cover $(PKGS)
 	# go test doesn't support colleting coverage across multiple packages,
 	# generate go test commands using go list and run go test for every package separately 
-	go list -f '"go test -short -race -cover -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kubernetes/kompose/...  | grep -v "vendor" | xargs -L 1 -P4 sh -c
+	go list -f '"go test -race -cover -v -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"' github.com/kubernetes/kompose/...  | grep -v "vendor" | xargs -L 1 -P4 sh -c
 
 
 # run openshift up/down tests


### PR DESCRIPTION
We shouldn't add "-short" as this may break testing. See:

```
-short
    Tell long-running tests to shorten their run time.
    It is off by default but set during all.bash so that installing
    the Go tree can run a sanity check but not spend time running
    exhaustive tests.
```