### PR TITLE
Bump Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ go_import_path: github.com/kubernetes/kompose
 
 matrix:
   include:
-    - go: 1.7
+    - go: "1.9"
       env: 
         # Only build docs once
         - BUILD_DOCS=yes
         # Test cross-compile as well
         - CROSS_COMPILE=yes
-    - go: 1.8
-    - go: 1.9
+    - go: "1.10"
+    - go: "1.11"
 
 install:
   - true

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test-dep:
 	go get github.com/modocache/gover
 	go get github.com/Masterminds/glide
 	go get github.com/sgotti/glide-vc
-	go get github.com/golang/lint/golint
+	go get golang.org/x/lint/golint
 	go get github.com/mitchellh/gox
 
 


### PR DESCRIPTION
Appears the the fetching of `lint` was recently broken and this appears to be a fix: https://github.com/golang/lint/issues/415