### PR TITLE
Add label support to named volumes in docker compose v3 to Kubernetes

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -143,13 +143,14 @@ type Ports struct {
 
 // Volumes holds the volume struct of container
 type Volumes struct {
-	SvcName    string // Service name to which volume is linked
-	MountPath  string // Mountpath extracted from docker-compose file
-	VFrom      string // denotes service name from which volume is coming
-	VolumeName string // name of volume if provided explicitly
-	Host       string // host machine address
-	Container  string // Mountpath
-	Mode       string // access mode for volume
-	PVCName    string // name of PVC
-	PVCSize    string // PVC size
+	SvcName       string // Service name to which volume is linked
+	MountPath     string // Mountpath extracted from docker-compose file
+	VFrom         string // denotes service name from which volume is coming
+	VolumeName    string // name of volume if provided explicitly
+	Host          string // host machine address
+	Container     string // Mountpath
+	Mode          string // access mode for volume
+	PVCName       string // name of PVC
+	PVCSize       string // PVC size
+	SelectorValue string // Value of the label selector
 }

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1018,7 +1018,9 @@ func (k *Kubernetes) Deploy(komposeObject kobject.KomposeObject, opt kobject.Con
 			if err != nil {
 				return err
 			}
-			log.Infof("Successfully created PersistentVolumeClaim: %s of size %s. If your cluster has dynamic storage provisioning, you don't have to do anything. Otherwise you have to create PersistentVolume to make PVC work", t.Name, PVCRequestSize)
+			storage := t.Spec.Resources.Requests[api.ResourceStorage]
+			capacity := storage.String()
+			log.Infof("Successfully created PersistentVolumeClaim: %s of size %s. If your cluster has dynamic storage provisioning, you don't have to do anything. Otherwise you have to create PersistentVolume to make PVC work", t.Name, capacity)
 		case *extensions.Ingress:
 			_, err := client.Ingress(namespace).Create(t)
 			if err != nil {

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -373,7 +373,7 @@ func (k *Kubernetes) initIngress(name string, service kobject.ServiceConfig, por
 }
 
 // CreatePVC initializes PersistentVolumeClaim
-func (k *Kubernetes) CreatePVC(name string, mode string, size string) (*api.PersistentVolumeClaim, error) {
+func (k *Kubernetes) CreatePVC(name string, mode string, size string, selectorValue string) (*api.PersistentVolumeClaim, error) {
 	volSize, err := resource.ParseQuantity(size)
 	if err != nil {
 		return nil, errors.Wrap(err, "resource.ParseQuantity failed, Error parsing size")
@@ -395,6 +395,12 @@ func (k *Kubernetes) CreatePVC(name string, mode string, size string) (*api.Pers
 				},
 			},
 		},
+	}
+
+	if len(selectorValue) > 0 {
+		pvc.Spec.Selector = &unversioned.LabelSelector{
+			MatchLabels: transformer.ConfigLabels(selectorValue),
+		}
 	}
 
 	if mode == "ro" {
@@ -588,7 +594,7 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 					}
 				}
 
-				createdPVC, err := k.CreatePVC(volumeName, volume.Mode, defaultSize)
+				createdPVC, err := k.CreatePVC(volumeName, volume.Mode, defaultSize, volume.SelectorValue)
 
 				if err != nil {
 					return nil, nil, nil, errors.Wrap(err, "k.CreatePVC failed")

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -578,9 +578,13 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 			if volume.VFrom == "" {
 				defaultSize := PVCRequestSize
 
-				for key, value := range service.Labels {
-					if key == "kompose.volume.size" {
-						defaultSize = value
+				if len(volume.PVCSize) > 0 {
+					defaultSize = volume.PVCSize
+				} else {
+					for key, value := range service.Labels {
+						if key == "kompose.volume.size" {
+							defaultSize = value
+						}
 					}
 				}
 

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -185,6 +185,10 @@ cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/named-volume/do
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/named-volume/output-k8s-template.json > /tmp/output-k8s.json
 convert::expect_success "$cmd" "/tmp/output-k8s.json"
 
+cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/named-volume/docker-compose-v3.yml convert --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/named-volume/output-k8s-v3.json > /tmp/output-k8s.json
+convert::expect_success "$cmd" "/tmp/output-k8s.json"
+
 # openshift test
 cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/named-volume/docker-compose.yml convert --stdout -j"
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/named-volume/output-os-template.json > /tmp/output-os.json

--- a/script/test/fixtures/volume-mounts/named-volume/docker-compose-v3.yml
+++ b/script/test/fixtures/volume-mounts/named-volume/docker-compose-v3.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  db:
+    image: postgres:10.1
+    ports:
+      - "5432"
+    labels:
+      kompose.volume.size: 200Mi
+    volumes:
+      - db-data:/var/lib/postgresql/data
+      - db-config:/var/lib/postgresql/config
+volumes:
+  db-data:
+    labels:
+      kompose.volume.selector: db-data-dev
+      kompose.volume.size: 500Mi

--- a/script/test/fixtures/volume-mounts/named-volume/output-k8s-v3.json
+++ b/script/test/fixtures/volume-mounts/named-volume/output-k8s-v3.json
@@ -1,0 +1,157 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.volume.size": "200Mi"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5432",
+            "port": 5432,
+            "targetPort": 5432
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "db"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        },
+        "annotations": {
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "kompose.volume.size": "200Mi"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "db"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "db-data",
+                "persistentVolumeClaim": {
+                  "claimName": "db-data"
+                }
+              },
+              {
+                "name": "db-config",
+                "persistentVolumeClaim": {
+                  "claimName": "db-config"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "db",
+                "image": "postgres:10.1",
+                "ports": [
+                  {
+                    "containerPort": 5432
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "db-data",
+                    "mountPath": "/var/lib/postgresql/data"
+                  },
+                  {
+                    "name": "db-config",
+                    "mountPath": "/var/lib/postgresql/config"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {
+          "type": "Recreate"
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db-data",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db-data"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "selector": {
+          "matchLabels": {
+            "io.kompose.service": "db-data-dev"
+          }
+        },
+        "resources": {
+          "requests": {
+            "storage": "500Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db-config",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db-config"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "200Mi"
+          }
+        }
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
1.  Add the below labels support to named volumes:
- `kompose.volume.selector` - Add selector.matchLabels to kubernetes PVC for volume binding
- `kompose.volume.size` - Change kubernetes supported volume size for docker named volumes

```
volumes:
  database-vol:
    labels:
      kompose.volume.selector: database-vol-dev
      kompose.volume.size: 500Mi
```

For example, the above named volume (database-vol) defined in docker compose file will convert to following Kubernetes config

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  creationTimestamp: null
  labels:
    io.kompose.service: database-vol
  name: database-vol
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 200Mi
  selector:
    matchLabels:
      io.kompose.service: database-vol-dev
status: {}
```

2. Fix the PVC size in log message when deploy Kubernetes

3. Skip creation of PVC if it is already created in the same kubernetes deploy
