### PR TITLE
fix: hostpath volume supoort for docker-compose v3 file

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -209,6 +209,19 @@ hostpath=$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/data
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  -e "s;%HOSTPATH%;$hostpath;g" $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/output-os-template.json > /tmp/output-os.json
 convert::expect_success "$cmd" "/tmp/output-os.json"
 
+# v3 kubernetes test
+cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/docker-compose-v3.yml convert --stdout -j --volumes hostPath"
+hostpath=$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/data
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g" -e "s;%HOSTPATH%;$hostpath;g" $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/output-k8s-template.json > /tmp/output-k8s.json
+convert::expect_success "$cmd" "/tmp/output-k8s.json"
+
+# v3 openshift test
+cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/docker-compose-v3.yml convert --stdout -j --volumes hostPath"
+hostpath=$KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/data
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  -e "s;%HOSTPATH%;$hostpath;g" $KOMPOSE_ROOT/script/test/fixtures/volume-mounts/hostpath/output-os-template.json > /tmp/output-os.json
+convert::expect_success "$cmd" "/tmp/output-os.json"
+
+
 ######
 # Tests related to docker-compose file in /script/test/fixtures/volume-mounts/volumes-from
 # kubernetes test

--- a/script/test/fixtures/volume-mounts/hostpath/docker-compose-v3.yml
+++ b/script/test/fixtures/volume-mounts/hostpath/docker-compose-v3.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  db:
+    image: postgres:10.1
+    ports:
+      - "5432"
+    volumes:
+      - ./data:/var/lib/postgresql/data


### PR DESCRIPTION
fix #1089 
The problem is that in v3, we use the "long syntax" for volumes in terms of parsing.
So the path is already an absolute path. We don't need to join it with dir.
Therefore, the idea is to simply get the docker-compose file version and use switch case.