### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -176,12 +176,12 @@ func formatProviderName(provider string) string {
 // EnvSort struct
 type EnvSort []api.EnvVar
 
-// returns the number of elements in the collection.
+// Len returns the number of elements in the collection.
 func (env EnvSort) Len() int {
 	return len(env)
 }
 
-// returns whether the element with index i should sort before
+// Less returns whether the element with index i should sort before
 // the element with index j.
 func (env EnvSort) Less(i, j int) bool {
 	return env[i].Name < env[j].Name


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?