### PR TITLE
Revert "Add node references"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Convert [`docker-compose.yaml`](https://raw.githubusercontent.com/kubernetes/kom
 $ kompose convert -f docker-compose.yaml
 INFO Kubernetes file "frontend-service.yaml" created         
 INFO Kubernetes file "redis-master-service.yaml" created     
-INFO Kubernetes file "redis-node-service.yaml" created      
+INFO Kubernetes file "redis-slave-service.yaml" created      
 INFO Kubernetes file "frontend-deployment.yaml" created      
 INFO Kubernetes file "redis-master-deployment.yaml" created  
-INFO Kubernetes file "redis-node-deployment.yaml" created 
+INFO Kubernetes file "redis-slave-deployment.yaml" created 
 ```
 
 Other examples are provided in the _examples_ [directory](./examples).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,10 +48,10 @@ Run `kompose convert` in the same directory as your `docker-compose.yaml` file.
 $ kompose convert                           
 INFO Kubernetes file "frontend-service.yaml" created         
 INFO Kubernetes file "redis-master-service.yaml" created     
-INFO Kubernetes file "redis-node-service.yaml" created      
+INFO Kubernetes file "redis-slave-service.yaml" created      
 INFO Kubernetes file "frontend-deployment.yaml" created      
 INFO Kubernetes file "redis-master-deployment.yaml" created  
-INFO Kubernetes file "redis-node-deployment.yaml" created 
+INFO Kubernetes file "redis-slave-deployment.yaml" created 
 ```
 
 Alternatively, you can convert and deploy directly to Kubernetes with `kompose up`.
@@ -152,13 +152,13 @@ Run `kompose convert --provider=openshift` in the same directory as your `docker
 $ kompose convert --provider=openshift
 INFO OpenShift file "frontend-service.yaml" created 
 INFO OpenShift file "redis-master-service.yaml" created 
-INFO OpenShift file "redis-node-service.yaml" created 
+INFO OpenShift file "redis-slave-service.yaml" created 
 INFO OpenShift file "frontend-deploymentconfig.yaml" created 
 INFO OpenShift file "frontend-imagestream.yaml" created 
 INFO OpenShift file "redis-master-deploymentconfig.yaml" created 
 INFO OpenShift file "redis-master-imagestream.yaml" created 
-INFO OpenShift file "redis-node-deploymentconfig.yaml" created 
-INFO OpenShift file "redis-node-imagestream.yaml" created 
+INFO OpenShift file "redis-slave-deploymentconfig.yaml" created 
+INFO OpenShift file "redis-slave-imagestream.yaml" created 
 ```
 
 Alternatively, you can convert and deploy directly to OpenShift with `kompose up --provider=openshift`.
@@ -171,13 +171,13 @@ If you need different kind of resources, use the 'kompose convert' and 'oc creat
 INFO Deploying application in "myproject" namespace 
 INFO Successfully created Service: frontend       
 INFO Successfully created Service: redis-master   
-INFO Successfully created Service: redis-node    
+INFO Successfully created Service: redis-slave    
 INFO Successfully created DeploymentConfig: frontend 
 INFO Successfully created ImageStream: frontend   
 INFO Successfully created DeploymentConfig: redis-master 
 INFO Successfully created ImageStream: redis-master 
-INFO Successfully created DeploymentConfig: redis-node 
-INFO Successfully created ImageStream: redis-node 
+INFO Successfully created DeploymentConfig: redis-slave 
+INFO Successfully created ImageStream: redis-slave 
 
 Your application has been deployed to OpenShift. You can run 'oc get dc,svc,is,pvc' for details.
 ```
@@ -290,13 +290,13 @@ Run `kompose convert --provider=openshift` in the same directory as your `docker
 $ kompose convert --provider=openshift
 INFO OpenShift file "frontend-service.yaml" created 
 INFO OpenShift file "redis-master-service.yaml" created 
-INFO OpenShift file "redis-node-service.yaml" created 
+INFO OpenShift file "redis-slave-service.yaml" created 
 INFO OpenShift file "frontend-deploymentconfig.yaml" created 
 INFO OpenShift file "frontend-imagestream.yaml" created 
 INFO OpenShift file "redis-master-deploymentconfig.yaml" created 
 INFO OpenShift file "redis-master-imagestream.yaml" created 
-INFO OpenShift file "redis-node-deploymentconfig.yaml" created 
-INFO OpenShift file "redis-node-imagestream.yaml" created 
+INFO OpenShift file "redis-slave-deploymentconfig.yaml" created 
+INFO OpenShift file "redis-slave-imagestream.yaml" created 
 ```
 
 Alternatively, you can convert and deploy directly to OpenShift with `kompose up --provider=openshift`.
@@ -309,13 +309,13 @@ If you need different kind of resources, use the 'kompose convert' and 'oc creat
 INFO Deploying application in "myproject" namespace 
 INFO Successfully created Service: frontend       
 INFO Successfully created Service: redis-master   
-INFO Successfully created Service: redis-node    
+INFO Successfully created Service: redis-slave    
 INFO Successfully created DeploymentConfig: frontend 
 INFO Successfully created ImageStream: frontend   
 INFO Successfully created DeploymentConfig: redis-master 
 INFO Successfully created ImageStream: redis-master 
-INFO Successfully created DeploymentConfig: redis-node 
-INFO Successfully created ImageStream: redis-node 
+INFO Successfully created DeploymentConfig: redis-slave 
+INFO Successfully created ImageStream: redis-slave 
 
 Your application has been deployed to OpenShift. You can run 'oc get dc,svc,is,pvc' for details.
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -36,7 +36,7 @@ $ kubectl get po
 NAME                            READY     STATUS              RESTARTS   AGE
 frontend-591253677-5t038        1/1       Running             0          10s
 redis-master-2410703502-9hshf   1/1       Running             0          10s
-redis-node-4049176185-hr1lr     1/1       Running             0          10s
+redis-slave-4049176185-hr1lr    1/1       Running             0          10s
 ```
 
 A more detailed guide is available in our [getting started guide](/docs/getting-started.md).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -41,18 +41,18 @@ INFO Kubernetes file "frontend-service.yaml" created
 INFO Kubernetes file "mlbparks-service.yaml" created         
 INFO Kubernetes file "mongodb-service.yaml" created          
 INFO Kubernetes file "redis-master-service.yaml" created     
-INFO Kubernetes file "redis-node-service.yaml" created      
+INFO Kubernetes file "redis-slave-service.yaml" created      
 INFO Kubernetes file "frontend-deployment.yaml" created      
 INFO Kubernetes file "mlbparks-deployment.yaml" created      
 INFO Kubernetes file "mongodb-deployment.yaml" created       
 INFO Kubernetes file "mongodb-claim0-persistentvolumeclaim.yaml" created 
 INFO Kubernetes file "redis-master-deployment.yaml" created  
-INFO Kubernetes file "redis-node-deployment.yaml" created   
+INFO Kubernetes file "redis-slave-deployment.yaml" created   
 
 $ ls
-mlbparks-deployment.yaml  mongodb-service.yaml                       redis-node-service.jsonmlbparks-service.yaml  
+mlbparks-deployment.yaml  mongodb-service.yaml                       redis-slave-service.jsonmlbparks-service.yaml  
 frontend-deployment.yaml  mongodb-claim0-persistentvolumeclaim.yaml  redis-master-service.yaml
-frontend-service.yaml     mongodb-deployment.yaml                    redis-node-deployment.yaml
+frontend-service.yaml     mongodb-deployment.yaml                    redis-slave-deployment.yaml
 redis-master-deployment.yaml
 ``` 
 
@@ -104,10 +104,10 @@ We are going to create Kubernetes deployments and services for your Dockerized a
 If you need different kind of resources, use the 'kompose convert' and 'kubectl create -f' commands instead.
 
 INFO Successfully created service: redis-master   
-INFO Successfully created service: redis-node    
+INFO Successfully created service: redis-slave    
 INFO Successfully created service: frontend       
 INFO Successfully created deployment: redis-master
-INFO Successfully created deployment: redis-node
+INFO Successfully created deployment: redis-slave
 INFO Successfully created deployment: frontend    
 
 Your application has been deployed to Kubernetes. You can run 'kubectl get deployment,svc,pods' for details.
@@ -116,18 +116,18 @@ $ kubectl get deployment,svc,pods
 NAME                               DESIRED       CURRENT       UP-TO-DATE   AVAILABLE   AGE
 deploy/frontend                    1             1             1            1           4m
 deploy/redis-master                1             1             1            1           4m
-deploy/redis-node                 1             1             1            1           4m
+deploy/redis-slave                 1             1             1            1           4m
 
 NAME                               CLUSTER-IP    EXTERNAL-IP   PORT(S)      AGE
 svc/frontend                       10.0.174.12   <none>        80/TCP       4m
 svc/kubernetes                     10.0.0.1      <none>        443/TCP      13d
 svc/redis-master                   10.0.202.43   <none>        6379/TCP     4m
-svc/redis-node                    10.0.1.85     <none>        6379/TCP     4m
+svc/redis-slave                    10.0.1.85     <none>        6379/TCP     4m
 
 NAME                               READY         STATUS        RESTARTS     AGE
 po/frontend-2768218532-cs5t5       1/1           Running       0            4m
 po/redis-master-1432129712-63jn8   1/1           Running       0            4m
-po/redis-node-2504961300-nve7b    1/1           Running       0            4m
+po/redis-slave-2504961300-nve7b    1/1           Running       0            4m
 ```
 Note:
 - You must have a running Kubernetes cluster with a pre-configured kubectl context.
@@ -139,11 +139,11 @@ $ kompose --file ./examples/docker-guestbook.yml --provider openshift up
 We are going to create OpenShift DeploymentConfigs and Services for your Dockerized application.
 If you need different kind of resources, use the 'kompose convert' and 'oc create -f' commands instead.
 
-INFO Successfully created service: redis-node    
+INFO Successfully created service: redis-slave    
 INFO Successfully created service: frontend       
 INFO Successfully created service: redis-master   
-INFO Successfully created deployment: redis-node
-INFO Successfully created ImageStream: redis-node
+INFO Successfully created deployment: redis-slave
+INFO Successfully created ImageStream: redis-slave
 INFO Successfully created deployment: frontend    
 INFO Successfully created ImageStream: frontend   
 INFO Successfully created deployment: redis-master
@@ -155,15 +155,15 @@ $ oc get dc,svc,is
 NAME               REVISION                              DESIRED       CURRENT    TRIGGERED BY
 dc/frontend        0                                     1             0          config,image(frontend:v4)
 dc/redis-master    0                                     1             0          config,image(redis-master:e2e)
-dc/redis-node     0                                     1             0          config,image(redis-node:v1)
+dc/redis-slave     0                                     1             0          config,image(redis-slave:v1)
 NAME               CLUSTER-IP                            EXTERNAL-IP   PORT(S)    AGE
 svc/frontend       172.30.46.64                          <none>        80/TCP     8s
 svc/redis-master   172.30.144.56                         <none>        6379/TCP   8s
-svc/redis-node    172.30.75.245                         <none>        6379/TCP   8s
+svc/redis-slave    172.30.75.245                         <none>        6379/TCP   8s
 NAME               DOCKER REPO                           TAGS          UPDATED
 is/frontend        172.30.12.200:5000/fff/frontend                     
 is/redis-master    172.30.12.200:5000/fff/redis-master                 
-is/redis-node     172.30.12.200:5000/fff/redis-node    v1  
+is/redis-slave     172.30.12.200:5000/fff/redis-slave    v1  
 ```
 
 Note:
@@ -177,8 +177,8 @@ Once you have deployed "composed" application to Kubernetes, `$ kompose down` wi
 $ kompose --file docker-guestbook.yml down
 INFO Successfully deleted service: redis-master   
 INFO Successfully deleted deployment: redis-master
-INFO Successfully deleted service: redis-node    
-INFO Successfully deleted deployment: redis-node
+INFO Successfully deleted service: redis-slave    
+INFO Successfully deleted deployment: redis-slave
 INFO Successfully deleted service: frontend       
 INFO Successfully deleted deployment: frontend
 ```

--- a/examples/docker-compose-v3.yaml
+++ b/examples/docker-compose-v3.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "6379"
 
-  redis-node:
+  redis-slave:
     image: gcr.io/google_samples/gb-redisslave:v1
     ports:
       - "6379"

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "6379"
 
-  redis-node:
+  redis-slave:
     image: gcr.io/google_samples/gb-redisslave:v1
     ports:
       - "6379"

--- a/script/test/fixtures/controller/docker-compose.yml
+++ b/script/test/fixtures/controller/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "6379"
 
-  redis-node:
+  redis-slave:
     image: gcr.io/google_samples/gb-redisslave:v1
     ports:
       - "6379"

--- a/script/test/fixtures/controller/output-k8s-daemonset-template.json
+++ b/script/test/fixtures/controller/output-k8s-daemonset-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -197,10 +197,10 @@
       "kind": "DaemonSet",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -212,13 +212,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/controller/output-k8s-deployment-template.json
+++ b/script/test/fixtures/controller/output-k8s-deployment-template.json
@@ -70,10 +70,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -89,7 +89,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -193,10 +193,10 @@
       "kind": "Deployment",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -209,13 +209,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/controller/output-k8s-rc-template.json
+++ b/script/test/fixtures/controller/output-k8s-rc-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -194,10 +194,10 @@
       "kind": "ReplicationController",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -210,13 +210,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/examples/output-k8s.json
+++ b/script/test/fixtures/examples/output-k8s.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -192,10 +192,10 @@
       "kind": "Deployment",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -208,13 +208,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/examples/output-os.json
+++ b/script/test/fixtures/examples/output-os.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -296,10 +296,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -319,11 +319,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "redis-node"
+                "redis-slave"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "redis-node:v1"
+                "name": "redis-slave:v1"
               }
             }
           }
@@ -331,19 +331,19 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": " ",
                 "ports": [
                   {
@@ -369,10 +369,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "spec": {

--- a/script/test/fixtures/examples/output-v3-k8s.json
+++ b/script/test/fixtures/examples/output-v3-k8s.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -192,10 +192,10 @@
       "kind": "Deployment",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -208,13 +208,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/examples/output-v3-os.json
+++ b/script/test/fixtures/examples/output-v3-os.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -296,10 +296,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -319,11 +319,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "redis-node"
+                "redis-slave"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "redis-node:v1"
+                "name": "redis-slave:v1"
               }
             }
           }
@@ -331,19 +331,19 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": " ",
                 "ports": [
                   {
@@ -369,10 +369,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "spec": {

--- a/script/test/fixtures/keyonly-envs/env.yml
+++ b/script/test/fixtures/keyonly-envs/env.yml
@@ -5,7 +5,7 @@ services:
     image: k8s.gcr.io/redis:e2e 
     ports:
       - "6379"
-  redis-node:
+  redis-slave:
     image: gcr.io/google_samples/gb-redisslave:v1
     ports:
       - "6379"

--- a/script/test/fixtures/keyonly-envs/output-k8s-template.json
+++ b/script/test/fixtures/keyonly-envs/output-k8s-template.json
@@ -67,10 +67,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -86,7 +86,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -201,10 +201,10 @@
       "kind": "Deployment",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -217,13 +217,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/v3/docker-compose.yaml
+++ b/script/test/fixtures/v3/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "6379"
 
-  redis-node:
+  redis-slave:
     image: gcr.io/google_samples/gb-redisslave:v1
     ports:
       - "6379"

--- a/script/test/fixtures/v3/output-k8s-template.json
+++ b/script/test/fixtures/v3/output-k8s-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -192,10 +192,10 @@
       "kind": "Deployment",
       "apiVersion": "extensions/v1beta1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -208,13 +208,13 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": "gcr.io/google_samples/gb-redisslave:v1",
                 "ports": [
                   {

--- a/script/test/fixtures/v3/output-os-template.json
+++ b/script/test/fixtures/v3/output-os-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "status": {
@@ -296,10 +296,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -319,11 +319,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "redis-node"
+                "redis-slave"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "redis-node:v1"
+                "name": "redis-slave:v1"
               }
             }
           }
@@ -331,19 +331,19 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-node"
+              "io.kompose.service": "redis-slave"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-node",
+                "name": "redis-slave",
                 "image": " ",
                 "ports": [
                   {
@@ -369,10 +369,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-node",
+        "name": "redis-slave",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-node"
+          "io.kompose.service": "redis-slave"
         }
       },
       "spec": {


### PR DESCRIPTION
Reverts kubernetes/kompose#1123

Reverts back to using "slave". Unfortunately, we rely on Google's examples. Once `google-samples` is updated to using `node` we'll switch back!