### PR TITLE
Change DaemonSet and Deployment to apiVersion apps/v1

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -294,7 +294,7 @@ func (k *Kubernetes) InitD(name string, service kobject.ServiceConfig, replicas 
 	dc := &extensions.Deployment{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Deployment",
-			APIVersion: "extensions/v1beta1",
+			APIVersion: "apps/v1",
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,
@@ -318,7 +318,7 @@ func (k *Kubernetes) InitDS(name string, service kobject.ServiceConfig) *extensi
 	ds := &extensions.DaemonSet{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "DaemonSet",
-			APIVersion: "extensions/v1beta1",
+			APIVersion: "apps/v1",
 		},
 		ObjectMeta: api.ObjectMeta{
 			Name:   name,

--- a/script/test/fixtures/bundles/dab/output-k8s.json
+++ b/script/test/fixtures/bundles/dab/output-k8s.json
@@ -57,7 +57,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -96,7 +96,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/bundles/dsb/output-k8s.json
+++ b/script/test/fixtures/bundles/dsb/output-k8s.json
@@ -142,7 +142,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,
@@ -184,7 +184,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -223,7 +223,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "result",
         "creationTimestamp": null,
@@ -262,7 +262,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "vote",
         "creationTimestamp": null,
@@ -304,7 +304,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "worker",
         "creationTimestamp": null,

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json
@@ -67,7 +67,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -111,7 +111,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/change-in-volume/output-k8s-template.json
+++ b/script/test/fixtures/change-in-volume/output-k8s-template.json
@@ -67,7 +67,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -111,7 +111,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/compose-v3.3-test/output-k8s-config-long-warning.json
+++ b/script/test/fixtures/compose-v3.3-test/output-k8s-config-long-warning.json
@@ -19,7 +19,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/compose-v3.3-test/output-k8s-config-long.json
+++ b/script/test/fixtures/compose-v3.3-test/output-k8s-config-long.json
@@ -19,7 +19,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/compose-v3.3-test/output-k8s-config-short-warning.json
+++ b/script/test/fixtures/compose-v3.3-test/output-k8s-config-short-warning.json
@@ -19,7 +19,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/compose-v3.3-test/output-k8s-config-short.json
+++ b/script/test/fixtures/compose-v3.3-test/output-k8s-config-short.json
@@ -19,7 +19,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/compose-v3.3-test/output-k8s-endpoint-mode-1.json
+++ b/script/test/fixtures/compose-v3.3-test/output-k8s-endpoint-mode-1.json
@@ -36,7 +36,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "wordpress",
         "creationTimestamp": null,

--- a/script/test/fixtures/compose-v3.3-test/output-k8s-endpoint-mode-2.json
+++ b/script/test/fixtures/compose-v3.3-test/output-k8s-endpoint-mode-2.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "wordpress",
         "creationTimestamp": null,

--- a/script/test/fixtures/configmap/output-k8s-template.json
+++ b/script/test/fixtures/configmap/output-k8s-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-k8s-controller-template.json
+++ b/script/test/fixtures/controller/output-k8s-controller-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,
@@ -83,7 +83,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-k8s-controller-v3-template.json
+++ b/script/test/fixtures/controller/output-k8s-controller-v3-template.json
@@ -36,7 +36,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "mysql",
         "creationTimestamp": null,
@@ -83,7 +83,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-k8s-daemonset-template.json
+++ b/script/test/fixtures/controller/output-k8s-daemonset-template.json
@@ -97,7 +97,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null,
@@ -150,7 +150,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,
@@ -195,7 +195,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-slave",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-k8s-deployment-template.json
+++ b/script/test/fixtures/controller/output-k8s-deployment-template.json
@@ -97,7 +97,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null,
@@ -152,7 +152,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,
@@ -199,7 +199,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-slave",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-k8s-global-deployment-template.json
+++ b/script/test/fixtures/controller/output-k8s-global-deployment-template.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "worker",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-k8s-global-template.json
+++ b/script/test/fixtures/controller/output-k8s-global-template.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "worker",
         "creationTimestamp": null,

--- a/script/test/fixtures/controller/output-os-controller-v3-template.json
+++ b/script/test/fixtures/controller/output-os-controller-v3-template.json
@@ -36,7 +36,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "mysql",
         "creationTimestamp": null,

--- a/script/test/fixtures/domain/output-k8s.json
+++ b/script/test/fixtures/domain/output-k8s.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "dns",
         "creationTimestamp": null,

--- a/script/test/fixtures/entrypoint-command/output-k8s-template.json
+++ b/script/test/fixtures/entrypoint-command/output-k8s-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "base",
         "creationTimestamp": null,

--- a/script/test/fixtures/env/output-k8s.json
+++ b/script/test/fixtures/env/output-k8s.json
@@ -40,7 +40,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "namenode",
         "creationTimestamp": null,

--- a/script/test/fixtures/envvars-separators/output-k8s-template.json
+++ b/script/test/fixtures/envvars-separators/output-k8s-template.json
@@ -95,7 +95,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-api",
         "creationTimestamp": null,
@@ -180,7 +180,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-bitbucket-scm-collector",
         "creationTimestamp": null,
@@ -260,7 +260,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-chat-ops-collector",
         "creationTimestamp": null,
@@ -340,7 +340,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-github-scm-collector",
         "creationTimestamp": null,
@@ -420,7 +420,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-jenkins-build-collector",
         "creationTimestamp": null,
@@ -500,7 +500,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-jenkins-cucumber-test-collector",
         "creationTimestamp": null,
@@ -580,7 +580,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-jira-feature-collector",
         "creationTimestamp": null,
@@ -670,7 +670,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-sonar-codequality-collector",
         "creationTimestamp": null,
@@ -750,7 +750,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-subversion-scm-collector",
         "creationTimestamp": null,
@@ -830,7 +830,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-udeploy-collector",
         "creationTimestamp": null,
@@ -924,7 +924,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-ui",
         "creationTimestamp": null,
@@ -971,7 +971,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "hygieia-versionone-collector",
         "creationTimestamp": null,
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "mongodb",
         "creationTimestamp": null,

--- a/script/test/fixtures/etherpad/output-k8s-template.json
+++ b/script/test/fixtures/etherpad/output-k8s-template.json
@@ -65,7 +65,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "etherpad",
         "creationTimestamp": null,
@@ -134,7 +134,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "mariadb",
         "creationTimestamp": null,

--- a/script/test/fixtures/examples/output-counter-k8s.json
+++ b/script/test/fixtures/examples/output-counter-k8s.json
@@ -65,7 +65,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -112,7 +112,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/examples/output-counter-v3-k8s.json
+++ b/script/test/fixtures/examples/output-counter-v3-k8s.json
@@ -67,7 +67,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -114,7 +114,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/examples/output-gitlab-k8s.json
+++ b/script/test/fixtures/examples/output-gitlab-k8s.json
@@ -102,7 +102,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "gitlab",
         "creationTimestamp": null,
@@ -526,7 +526,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "postgresql",
         "creationTimestamp": null,
@@ -629,7 +629,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/examples/output-k8s.json
+++ b/script/test/fixtures/examples/output-k8s.json
@@ -97,7 +97,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null,
@@ -152,7 +152,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,
@@ -199,7 +199,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-slave",
         "creationTimestamp": null,

--- a/script/test/fixtures/examples/output-v3-k8s.json
+++ b/script/test/fixtures/examples/output-v3-k8s.json
@@ -97,7 +97,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null,
@@ -152,7 +152,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,
@@ -199,7 +199,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-slave",
         "creationTimestamp": null,

--- a/script/test/fixtures/examples/output-voting-k8s.json
+++ b/script/test/fixtures/examples/output-voting-k8s.json
@@ -127,7 +127,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,
@@ -176,7 +176,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -223,7 +223,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "result",
         "creationTimestamp": null,
@@ -270,7 +270,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "vote",
         "creationTimestamp": null,
@@ -319,7 +319,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "worker",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-multiple-ports.json
@@ -71,7 +71,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -118,7 +118,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -170,7 +170,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-tls.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname-tls.json
@@ -67,7 +67,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -114,7 +114,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -165,7 +165,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-hostname.json
@@ -66,7 +66,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -113,7 +113,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -162,7 +162,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-multiple-hostname-tls.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-multiple-hostname-tls.json
@@ -67,7 +67,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -114,7 +114,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -165,7 +165,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-multiple-hostname.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-multiple-hostname.json
@@ -66,7 +66,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -113,7 +113,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -162,7 +162,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true-multiple-ports.json
@@ -71,7 +71,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -118,7 +118,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -170,7 +170,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json
+++ b/script/test/fixtures/expose-service/provider-files/kubernetes-expose-true.json
@@ -66,7 +66,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -113,7 +113,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,
@@ -162,7 +162,7 @@
     },
     {
       "kind": "Ingress",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/gitlab/output-k8s-template.json
+++ b/script/test/fixtures/gitlab/output-k8s-template.json
@@ -105,7 +105,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "gitlab",
         "creationTimestamp": null,
@@ -192,7 +192,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "postgresql",
         "creationTimestamp": null,
@@ -253,7 +253,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/group-add/output-k8s.json
+++ b/script/test/fixtures/group-add/output-k8s.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "myservice",
         "creationTimestamp": null,

--- a/script/test/fixtures/healthcheck/output-k8s-template.json
+++ b/script/test/fixtures/healthcheck/output-k8s-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/healthcheck/output-only-command-k8s-template.json
+++ b/script/test/fixtures/healthcheck/output-only-command-k8s-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/image-pull-policy/provider-files/kubernetes-v12-image-pull-policy.json
+++ b/script/test/fixtures/image-pull-policy/provider-files/kubernetes-v12-image-pull-policy.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx0",
         "creationTimestamp": null,

--- a/script/test/fixtures/image-pull-policy/provider-files/kubernetes-v3-image-pull-policy.json
+++ b/script/test/fixtures/image-pull-policy/provider-files/kubernetes-v3-image-pull-policy.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx0",
         "creationTimestamp": null,
@@ -50,7 +50,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx1",
         "creationTimestamp": null,
@@ -95,7 +95,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx2",
         "creationTimestamp": null,

--- a/script/test/fixtures/image-pull-secret/provider-files/kubernetes-image-pull-secret.json
+++ b/script/test/fixtures/image-pull-secret/provider-files/kubernetes-image-pull-secret.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "open-image-service",
         "creationTimestamp": null,
@@ -47,7 +47,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "tm-image-service",
         "creationTimestamp": null,

--- a/script/test/fixtures/keyonly-envs/output-k8s-template.json
+++ b/script/test/fixtures/keyonly-envs/output-k8s-template.json
@@ -95,7 +95,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null,
@@ -160,7 +160,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,
@@ -207,7 +207,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-slave",
         "creationTimestamp": null,

--- a/script/test/fixtures/mem-limit/output-k8s-template.json
+++ b/script/test/fixtures/mem-limit/output-k8s-template.json
@@ -41,7 +41,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/mem-limit/output-mb-k8s-template.json
+++ b/script/test/fixtures/mem-limit/output-mb-k8s-template.json
@@ -41,7 +41,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/merge-multiple-compose/output-base-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-base-template.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "new-my-service",
         "creationTimestamp": null,
@@ -77,7 +77,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "server",
         "creationTimestamp": null,

--- a/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "server",
         "creationTimestamp": null,

--- a/script/test/fixtures/multiple-compose-files/output-k8s-template.json
+++ b/script/test/fixtures/multiple-compose-files/output-k8s-template.json
@@ -75,7 +75,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "etherpad",
         "creationTimestamp": null,
@@ -147,7 +147,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "mariadb",
         "creationTimestamp": null,

--- a/script/test/fixtures/nginx-node-redis/output-k8s-template-v3.json
+++ b/script/test/fixtures/nginx-node-redis/output-k8s-template-v3.json
@@ -155,7 +155,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx",
         "creationTimestamp": null,
@@ -202,7 +202,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "node1",
         "creationTimestamp": null,
@@ -249,7 +249,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "node2",
         "creationTimestamp": null,
@@ -296,7 +296,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "node3",
         "creationTimestamp": null,
@@ -343,7 +343,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/nginx-node-redis/output-k8s-template.json
+++ b/script/test/fixtures/nginx-node-redis/output-k8s-template.json
@@ -155,7 +155,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx",
         "creationTimestamp": null,
@@ -202,7 +202,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "node1",
         "creationTimestamp": null,
@@ -249,7 +249,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "node2",
         "creationTimestamp": null,
@@ -296,7 +296,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "node3",
         "creationTimestamp": null,
@@ -343,7 +343,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/placement/output-k8s-array-template.json
+++ b/script/test/fixtures/placement/output-k8s-array-template.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,

--- a/script/test/fixtures/placement/output-k8s-template.json
+++ b/script/test/fixtures/placement/output-k8s-template.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,

--- a/script/test/fixtures/ports-with-ip/output-k8s-template.json
+++ b/script/test/fixtures/ports-with-ip/output-k8s-template.json
@@ -71,7 +71,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -122,7 +122,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/ports-with-ip/output-k8s.json
+++ b/script/test/fixtures/ports-with-ip/output-k8s.json
@@ -71,7 +71,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -118,7 +118,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/ports-with-proto/output-k8s-template.json
+++ b/script/test/fixtures/ports-with-proto/output-k8s-template.json
@@ -71,7 +71,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -122,7 +122,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/restart-options/output-k8s-restart-unless-stopped.json
+++ b/script/test/fixtures/restart-options/output-k8s-restart-unless-stopped.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/same-port-different-proto/output-k8s-template.json
+++ b/script/test/fixtures/same-port-different-proto/output-k8s-template.json
@@ -77,7 +77,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -132,7 +132,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/service-name-change/output-k8s-template.json
+++ b/script/test/fixtures/service-name-change/output-k8s-template.json
@@ -72,7 +72,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "mariadb",
         "creationTimestamp": null,
@@ -168,7 +168,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "wordpress",
         "creationTimestamp": null,

--- a/script/test/fixtures/stdin-true/output-k8s-template.json
+++ b/script/test/fixtures/stdin-true/output-k8s-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "client",
         "creationTimestamp": null,

--- a/script/test/fixtures/stdin/output-k8s.json
+++ b/script/test/fixtures/stdin/output-k8s.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "backend",
         "creationTimestamp": null,

--- a/script/test/fixtures/stdin/output.json
+++ b/script/test/fixtures/stdin/output.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,

--- a/script/test/fixtures/tty-true/output-k8s-template.json
+++ b/script/test/fixtures/tty-true/output-k8s-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "client",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-deploy-mode-k8s-template.json
+++ b/script/test/fixtures/v3/output-deploy-mode-k8s-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-deploy-mode-os-template.json
+++ b/script/test/fixtures/v3/output-deploy-mode-os-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "DaemonSet",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-env-k8s.json
+++ b/script/test/fixtures/v3/output-env-k8s.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-env-subs.json
+++ b/script/test/fixtures/v3/output-env-subs.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-k8s-3.5.json
+++ b/script/test/fixtures/v3/output-k8s-3.5.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "helloworld",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-k8s-template.json
+++ b/script/test/fixtures/v3/output-k8s-template.json
@@ -97,7 +97,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "frontend",
         "creationTimestamp": null,
@@ -152,7 +152,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,
@@ -199,7 +199,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-slave",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-memcpu-k8s.json
+++ b/script/test/fixtures/v3/output-memcpu-k8s.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-memcpu-partial-k8s.json
+++ b/script/test/fixtures/v3/output-memcpu-partial-k8s.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-unset-env-k8s.json
+++ b/script/test/fixtures/v3/output-unset-env-k8s.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/v3/output-volumes-k8s-template.json
+++ b/script/test/fixtures/v3/output-volumes-k8s-template.json
@@ -37,7 +37,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foobar",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/hostpath/output-k8s-template.json
+++ b/script/test/fixtures/volume-mounts/hostpath/output-k8s-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/named-volume/output-k8s-template.json
+++ b/script/test/fixtures/volume-mounts/named-volume/output-k8s-template.json
@@ -36,7 +36,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/named-volume/output-k8s-v3.json
+++ b/script/test/fixtures/volume-mounts/named-volume/output-k8s-v3.json
@@ -36,7 +36,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "db",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/simple-vol-mounts/output-k8s-template.json
+++ b/script/test/fixtures/volume-mounts/simple-vol-mounts/output-k8s-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "httpd",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/tmpfs/output-k8s-template.json
+++ b/script/test/fixtures/volume-mounts/tmpfs/output-k8s-template.json
@@ -35,7 +35,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis-master",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/volumes-from/output-k8s-case.json
+++ b/script/test/fixtures/volume-mounts/volumes-from/output-k8s-case.json
@@ -86,7 +86,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "bar",
         "creationTimestamp": null,
@@ -192,7 +192,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "cat",
         "creationTimestamp": null,
@@ -268,7 +268,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "foo",
         "creationTimestamp": null,

--- a/script/test/fixtures/volume-mounts/volumes-from/output-k8s-template.json
+++ b/script/test/fixtures/volume-mounts/volumes-from/output-k8s-template.json
@@ -65,7 +65,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "nginx",
         "creationTimestamp": null,
@@ -160,7 +160,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/yaml-and-yml/output-k8s-template.json
+++ b/script/test/fixtures/yaml-and-yml/output-k8s-template.json
@@ -65,7 +65,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -112,7 +112,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,

--- a/script/test/fixtures/yaml-and-yml/yml/output-k8s-template.json
+++ b/script/test/fixtures/yaml-and-yml/yml/output-k8s-template.json
@@ -65,7 +65,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "redis",
         "creationTimestamp": null,
@@ -112,7 +112,7 @@
     },
     {
       "kind": "Deployment",
-      "apiVersion": "extensions/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "web",
         "creationTimestamp": null,


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#deprecations-and-removals

```

DaemonSet, Deployment, and ReplicaSet resources will no longer be served from extensions/v1beta1, apps/v1beta1, or apps/v1beta2 in v1.16. Migrate to the apps/v1 API, available since v1.9. Existing persisted data can be retrieved via the apps/v1 API.
```