### PR TITLE
Treat network as namespace

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -75,6 +75,7 @@ type ServiceConfig struct {
 	Args             []string            `compose:"args"`
 	VolList          []string            `compose:"volumes"`
 	Network          []string            `compose:"network"`
+	Namespace        Namespace           `compose:""`
 	Labels           map[string]string   `compose:"labels"`
 	Annotations      map[string]string   `compose:""`
 	CPUSet           string              `compose:"cpuset"`
@@ -127,6 +128,12 @@ type HealthCheck struct {
 	Retries     int32
 	StartPeriod int32
 	Disable     bool
+}
+
+// Namespace holds configuration for a service namespace
+type Namespace struct {
+	Name   string
+	Create bool
 }
 
 // EnvVar holds the environment variable struct of a container


### PR DESCRIPTION
This PR should resolve https://github.com/kubernetes/kompose/issues/1066 by converting the network as namespace.
- All objects generated for the specific service will have the namespace set as the network name
- When have `external: true` it not create the namespace yaml

_PS: I cound't test for openshift since i have no knowledge of it, but i make the same change since the logic is the same. May need some help for test for openshift!_