### PR TITLE
Copy service labels (annotations) also to Deployment template to Pods

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -303,6 +303,9 @@ func (k *Kubernetes) InitD(name string, service kobject.ServiceConfig, replicas 
 		Spec: extensions.DeploymentSpec{
 			Replicas: int32(replicas),
 			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: transformer.ConfigAnnotations(service),
+				},
 				Spec: podSpec,
 			},
 		},


### PR DESCRIPTION
At GetNinjas we are trying Kompose.

Having our Kubernetes configured with kube2iam, the Pods needs to have the IAM role annotated on its metadata, as said on [its readme](https://github.com/jtblin/kube2iam#kubernetes-annotation):
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: aws-cli
  labels:
    name: aws-cli
  annotations:
    iam.amazonaws.com/role: role-arn
    iam.amazonaws.com/external-id: external-id
spec:
  containers:
  - image: fstab/aws-cli
    command:
      - "/home/aws/aws/env/bin/aws"
      - "s3"
      - "ls"
      - "some-bucket"
    name: aws-cli
```

The way for this to happen is to include the labels from docker-compose service into the deployment template for pods, as this PR does.

(cc: @OtavioHenrique @adelsjnr)