### PR TITLE
Add note about output directories to convert --help

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -133,7 +133,7 @@ func init() {
 	convertCmd.Flags().MarkShorthandDeprecated("y", "YAML is the default format now.")
 	convertCmd.Flags().BoolVarP(&ConvertJSON, "json", "j", false, "Generate resource files into JSON format")
 	convertCmd.Flags().BoolVar(&ConvertStdout, "stdout", false, "Print converted objects to stdout")
-	convertCmd.Flags().StringVarP(&ConvertOut, "out", "o", "", "Specify a file name to save objects to")
+	convertCmd.Flags().StringVarP(&ConvertOut, "out", "o", "", "Specify a file name or directory to save objects to (if path does not exist, a file will be created)")
 	convertCmd.Flags().IntVar(&ConvertReplicas, "replicas", 1, "Specify the number of replicas in the generated resource spec")
 	convertCmd.Flags().StringVar(&ConvertVolumes, "volumes", "persistentVolumeClaim", `Volumes to be generated ("persistentVolumeClaim"|"emptyDir"|"hostPath")`)
 


### PR DESCRIPTION
This extends the `kompose convert --help` output slightly to extend the text for `--out` flag. Otherwise, users don't know that the `--out` flag can be used to specify a directory, to have kompose output multiple files in another directory instead of the current directory.

Diff of `kompose convert --help`:

```diff
@@ -20,7 +20,7 @@
       --controller string   Set the output controller ("deployment"|"daemonSet"|"replicationController")
   -h, --help                help for convert
   -j, --json                Generate resource files into JSON format
-  -o, --out string          Specify a file name to save objects to
+  -o, --out string          Specify a file name or directory to save objects to (if path does not exist, a file will be created)
       --replicas int        Specify the number of replicas in the generated resource spec (default 1)
       --stdout              Print converted objects to stdout
       --volumes string      Volumes to be generated ("persistentVolumeClaim"|"emptyDir"|"hostPath") (default "persistentVolumeClaim")
```

Fixes: #1170 