### PR TITLE
fix golint error about comment on exported variable

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -30,7 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//
+// StdinData is data bytes read from stdin
 var StdinData []byte
 
 // Compose is docker compose file loader, implements Loader interface


### PR DESCRIPTION
```
root@kubernetes:~/workspace/code/src/k8s.io/kompose# make lint
golint ./cmd/... ./pkg/... ./script/... .
pkg/loader/compose/compose.go:33:1: comment on exported var StdinData should be of the form "StdinData ..."
```

* add comment for variable exported variable `StdinData`

```
root@kubernetes:~/workspace/code/src/k8s.io/kompose# make lint
golint ./cmd/... ./pkg/... ./script/... .
```