### PR TITLE
fix tests related to secrets

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -621,17 +621,6 @@ func GetEnvsFromFile(file string, opt kobject.ConvertOptions) (map[string]string
 	return envLoad, nil
 }
 
-// GetSecretDataFromFile load secret content data
-func GetSecretDataFromFile(file string, opt kobject.ConvertOptions) ([]byte, error) {
-	composeDir, err := transformer.GetComposeFileDir(opt.InputFiles)
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to load file context")
-	}
-	fileLocation := path.Join(composeDir, file)
-	return ioutil.ReadFile(fileLocation)
-}
-
-// TODO(hang): merge these two functions
 // GetContentFromFile gets the content from the file..
 func GetContentFromFile(file string, opt kobject.ConvertOptions) (string, error) {
 	fileBytes, err := ioutil.ReadFile(file)

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -45,6 +45,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
+
 	//"k8s.io/kubernetes/pkg/controller/daemon"
 	"sort"
 	"strings"
@@ -397,11 +398,12 @@ func (k *Kubernetes) CreateSecrets(komposeObject kobject.KomposeObject) ([]*api.
 	var objects []*api.Secret
 	for name, config := range komposeObject.Secrets {
 		if config.File != "" {
-			data, err := GetSecretDataFromFile(config.File, k.Opt)
+			dataString, err := GetContentFromFile(config.File, k.Opt)
 			if err != nil {
 				log.Fatal("unable to read secret from file: ", config.File)
 				return nil, err
 			}
+			data := []byte(dataString)
 			secret := &api.Secret{
 				TypeMeta: unversioned.TypeMeta{
 					Kind:       "Secret",

--- a/script/test/fixtures/secrets/output-long-k8s.json
+++ b/script/test/fixtures/secrets/output-long-k8s.json
@@ -39,6 +39,10 @@
             "creationTimestamp": null,
             "labels": {
               "io.kompose.service": "redis"
+            },
+            "annotations": {
+              "kompose.cmd": "%CMD%",
+              "kompose.version": "%VERSION%"
             }
           },
           "spec": {
@@ -65,7 +69,7 @@
                 "volumeMounts": [
                   {
                     "name": "my_secret",
-                    "mountPath": "/run/secrets"
+                    "mountPath": "/run/secrets/my_secret"
                   }
                 ]
               }

--- a/script/test/fixtures/secrets/output-long-os.json
+++ b/script/test/fixtures/secrets/output-long-os.json
@@ -90,7 +90,7 @@
                 "volumeMounts": [
                   {
                     "name": "my_secret",
-                    "mountPath": "/run/secrets"
+                    "mountPath": "/run/secrets/my_secret"
                   }
                 ]
               }

--- a/script/test/fixtures/secrets/output-short-k8s.json
+++ b/script/test/fixtures/secrets/output-short-k8s.json
@@ -39,6 +39,10 @@
             "creationTimestamp": null,
             "labels": {
               "io.kompose.service": "redis"
+            },
+            "annotations": {
+              "kompose.cmd": "%CMD%",
+              "kompose.version": "%VERSION%"
             }
           },
           "spec": {
@@ -76,11 +80,11 @@
                 "volumeMounts": [
                   {
                     "name": "my_secret",
-                    "mountPath": "/run/secrets"
+                    "mountPath": "/run/secrets/my_secret"
                   },
                   {
                     "name": "my_other_secret",
-                    "mountPath": "/run/secrets"
+                    "mountPath": "/run/secrets/my_other_secret"
                   }
                 ]
               }

--- a/script/test/fixtures/secrets/output-short-os.json
+++ b/script/test/fixtures/secrets/output-short-os.json
@@ -101,11 +101,11 @@
                 "volumeMounts": [
                   {
                     "name": "my_secret",
-                    "mountPath": "/run/secrets"
+                    "mountPath": "/run/secrets/my_secret"
                   },
                   {
                     "name": "my_other_secret",
-                    "mountPath": "/run/secrets"
+                    "mountPath": "/run/secrets/my_other_secret"
                   }
                 ]
               }


### PR DESCRIPTION
1. fix the path used to read secret data
without this fix, the path to the compose file is added to the already
absolute path, hence readFile was unable to find the secrets file

2. fix the expected json format
mountPath includes the entire path including the name of the secret