### PR TITLE
concat and merge service fields when merging compose files (#1186)

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -138,6 +138,10 @@ cmd="kompose --provider=openshift convert -f $KOMPOSE_ROOT/script/test/fixtures/
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/output-openshift-template.json > /tmp/output-os.json
 convert::expect_success "$cmd" "/tmp/output-os.json"
 
+cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/service-merge-concat-base.yml -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/service-merge-concat-override.yml --stdout -j"
+sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/output-service-merge-concat-template.json > /tmp/output-k8s.json
+convert::expect_success_and_warning "$cmd" "/tmp/output-k8s.json" "Volume mount on the host \"/override/dir\" isn't supported - ignoring path on the host"
+
 # Test other top level keys
 # In merge
 cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/other-toplevel-dev.yml -f $KOMPOSE_ROOT/script/test/fixtures/merge-multiple-compose/other-toplevel-ext.yml --stdout -j"

--- a/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-compose-new-service-template.json
@@ -20,6 +20,11 @@
       "spec": {
         "ports": [
           {
+            "name": "3000",
+            "port": 3000,
+            "targetPort": 3000
+          },
+          {
             "name": "5000",
             "port": 5000,
             "targetPort": 5000
@@ -123,6 +128,9 @@
                 "imagePullPolicy": "",
                 "name": "test-server",
                 "ports": [
+                  {
+                    "containerPort": 3000
+                  },
                   {
                     "containerPort": 5000
                   }

--- a/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-compose-port-template.json
@@ -20,6 +20,11 @@
       "spec": {
         "ports": [
           {
+            "name": "3000",
+            "port": 3000,
+            "targetPort": 3000
+          },
+          {
             "name": "5000",
             "port": 5000,
             "targetPort": 5000
@@ -73,6 +78,9 @@
                 "imagePullPolicy": "",
                 "name": "test-server",
                 "ports": [
+                  {
+                    "containerPort": 3000
+                  },
                   {
                     "containerPort": 5000
                   }

--- a/script/test/fixtures/merge-multiple-compose/output-openshift-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-openshift-template.json
@@ -20,6 +20,11 @@
       "spec": {
         "ports": [
           {
+            "name": "3000",
+            "port": 3000,
+            "targetPort": 3000
+          },
+          {
             "name": "5000",
             "port": 5000,
             "targetPort": 5000
@@ -177,6 +182,9 @@
                 "name": "test-server",
                 "image": " ",
                 "ports": [
+                  {
+                    "containerPort": 3000
+                  },
                   {
                     "containerPort": 5000
                   }

--- a/script/test/fixtures/merge-multiple-compose/output-service-merge-concat-template.json
+++ b/script/test/fixtures/merge-multiple-compose/output-service-merge-concat-template.json
@@ -1,0 +1,198 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "annotations": {
+          "complexlabel": "override",
+          "kompose.cmd": "%CMD%",
+          "kompose.version": "%VERSION%",
+          "simplelabel.first": "Foo",
+          "simplelabel.second": "Bar"
+        },
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server"
+        },
+        "name": "server"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "io.kompose.service": "server"
+          }
+        },
+        "strategy": {
+          "type": "Recreate"
+        },
+        "template": {
+          "metadata": {
+            "annotations": {
+              "complexlabel": "override",
+              "kompose.cmd": "%CMD%",
+              "kompose.version": "%VERSION%",
+              "simplelabel.first": "Foo",
+              "simplelabel.second": "Bar"
+            },
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "server"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "NEW_ONE",
+                    "value": "1234"
+                  },
+                  {
+                    "name": "SAMPLE_TO_BE_OVERRIDDEN",
+                    "value": "new"
+                  },
+                  {
+                    "name": "SIMPLE_ONE",
+                    "value": "true"
+                  }
+                ],
+                "image": "test",
+                "imagePullPolicy": "",
+                "name": "test-server",
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "mountPath": "/simple/base/volume",
+                    "name": "server-claim0"
+                  },
+                  {
+                    "mountPath": "/common/mount/point",
+                    "name": "server-claim1"
+                  },
+                  {
+                    "mountPath": "/additional/added/volume",
+                    "name": "server-claim2"
+                  },
+                  {
+                    "mountPath": "/base-tmpdir",
+                    "name": "server-tmpfs0"
+                  },
+                  {
+                    "mountPath": "/additional-tmpdir",
+                    "name": "server-tmpfs1"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always",
+            "serviceAccountName": "",
+            "volumes": [
+              {
+                "name": "server-claim0",
+                "persistentVolumeClaim": {
+                  "claimName": "server-claim0"
+                }
+              },
+              {
+                "name": "server-claim1",
+                "persistentVolumeClaim": {
+                  "claimName": "server-claim1"
+                }
+              },
+              {
+                "name": "server-claim2",
+                "persistentVolumeClaim": {
+                  "claimName": "server-claim2"
+                }
+              },
+              {
+                "emptyDir": {
+                  "medium": "Memory"
+                },
+                "name": "server-tmpfs0"
+              },
+              {
+                "emptyDir": {
+                  "medium": "Memory"
+                },
+                "name": "server-tmpfs1"
+              }
+            ]
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server-claim0",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server-claim0"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server-claim1",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server-claim1"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "server-claim2",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "server-claim2"
+        }
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "100Mi"
+          }
+        }
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/merge-multiple-compose/service-merge-concat-base.yml
+++ b/script/test/fixtures/merge-multiple-compose/service-merge-concat-base.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  server:
+    image: test
+    container_name: test_server
+    environment:
+      - SIMPLE_ONE=true
+      - SAMPLE_TO_BE_OVERRIDDEN=original
+    expose:
+      - "3000"
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
+    dns_search: first.search.domain.com
+    external_links:
+      - other_service_1
+      - common_service:alias1
+    labels:
+      - "simplelabel.first=Foo" 
+      - "complexlabel=original"
+    tmpfs:
+      - /base-tmpdir
+    volumes:
+      - /simple/base/volume
+      - /base/dir:/common/mount/point
+      

--- a/script/test/fixtures/merge-multiple-compose/service-merge-concat-override.yml
+++ b/script/test/fixtures/merge-multiple-compose/service-merge-concat-override.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  server:
+    image: test
+    container_name: test_server
+    environment:
+      - SAMPLE_TO_BE_OVERRIDDEN=new
+      - NEW_ONE=1234
+    expose:
+      - "5000"
+    dns: 9.9.9.9
+    dns_search:
+      - second.search.domain.com
+    external_links:
+      - other_service_2
+      - common_service:alias2
+    labels:
+      simplelabel.second: "Bar"
+      complexlabel: override
+    tmpfs: /additional-tmpdir
+    volumes:
+      - /additional/added/volume
+      - /override/dir:/common/mount/point


### PR DESCRIPTION
As a summary, the following is the break up of the keys specified to be merged/concated:

1. Done and tested
    - Env (merge)
    - Labels (merge)
    - Ports (concat)
    - Volumes (merge by mount dir)
    - Tmpfs (concat) 

2. Done, but not tested/useful (as these are not supported in kompose anyway)
   - DNS (concat)
   - DNS Search (concat)
   - External Links (concat)
   - Expose (concat)

3. Not done as it's not needed
   - Devices (merge)