### PR TITLE
Add MacPorts support to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Installation methods:
   - [CentOS](/docs/installation.md#centos)
   - [Fedora](/docs/installation.md#fedora)
   - [openSUSE/SLE](/docs/installation.md#opensusesle)
-  - [macOS (Homebrew)](/docs/installation.md#macos)
+  - [macOS (Homebrew and MacPorts)](/docs/installation.md#macos)
   - [Windows](/docs/installation.md#windows)
 
 #### Binary installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,10 +50,14 @@ sudo dnf -y install kompose
 ```
 
 #### macOS
-On macOS you can install latest release via [Homebrew](https://brew.sh):
+On macOS you can install latest release via [Homebrew](https://brew.sh) or [MacPorts](https://www.macports.org/).
 
 ```bash
+# Homebrew
 brew install kompose
+
+# MacPorts
+port install kompose
 ```
 
 #### Windows


### PR DESCRIPTION
Instructions to install kompose using MacPorts have been added to the documentation.

Cheers,
Enrico