### PR TITLE
Support node.role placement labels

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -31,7 +31,7 @@ __Glossary:__
 | deploy                 | -  | -  | ✓  |                                                             |                                                                                                                |
 | deploy: mode           | -  | -  | ✓  |                                                             |                                                                                                                |
 | deploy: replicas       | -  | -  | ✓  | Deployment.Spec.Replicas / DeploymentConfig.Spec.Replicas   |                                                                                                                |
-| deploy: placement      | -  | -  | ✓  | Pod.Spec.NodeSelector                                       |                                                                                                                |
+| deploy: placement      | -  | -  | ✓  | Pod.Spec.NodeSelector                                       |    Supported constraints: `node.hostname`, `node.role == worker`, `node.role == manager`, `engine.labels.operatingsystem` and `node.labels.xxx`                                                                                                         |
 | deploy: update_config  | -  | -  | ✓  | Workload.Spec.Strategy                                      | Deployment / DeploymentConfig                                                                                                               |
 | deploy: resources      | -  | -  | ✓  | Containers.Resources.Limits.Memory / Containers.Resources.Limits.CPU | Support for memory as well as cpu                                                                     |
 | deploy: restart_policy | -  | -  | ✓  | Pod generation                                              | This generated a Pod, see the [user guide on restart](http://kompose.io/user-guide/#restart)                   |
@@ -45,7 +45,7 @@ __Glossary:__
 | entrypoint             | ✓  | ✓  | ✓  | Pod.Spec.Container.Command                                  | Same as command                                                                                                |
 | env_file               | n  | n  | ✓  |                                                             |                                                                                                                |
 | environment            | ✓  | ✓  | ✓  | Pod.Spec.Container.Env                                      |                                                                                                                |
-| expose                 | ✓  | ✓  | ✓  | Service.Spec.Ports 
+| expose                 | ✓  | ✓  | ✓  | Service.Spec.Ports
 | endpoint_mode          | n  | n  | ✓  |                                                             | If endpoint_mode=vip, the created Service will be forced to set to NodePort type                               |
 | extends                | ✓  | ✓  | ✓  |                                                             | Extends by utilizing the same image supplied                                                                   |
 | external_links         | x  | x  | x  |                                                             | Kubernetes uses a flat-structure for all containers and thus external_links does not have a 1-1 conversion     |

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -17,10 +17,11 @@ limitations under the License.
 package compose
 
 import (
-	"github.com/spf13/cast"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/spf13/cast"
 
 	libcomposeyaml "github.com/docker/libcompose/yaml"
 
@@ -135,14 +136,18 @@ func parseV3(files []string) (kobject.KomposeObject, error) {
 
 func loadV3Placement(constraints []string) map[string]string {
 	placement := make(map[string]string)
-	errMsg := " constraints in placement is not supported, only 'node.hostname', 'engine.labels.operatingsystem' and 'node.labels.xxx' (ex: node.labels.something == anything) is supported as a constraint "
+	errMsg := " constraints in placement is not supported, only 'node.hostname', 'node.role == worker', 'node.role == manager', 'engine.labels.operatingsystem' and 'node.labels.xxx' (ex: node.labels.something == anything) is supported as a constraint "
 	for _, j := range constraints {
 		p := strings.Split(j, " == ")
 		if len(p) < 2 {
 			log.Warn(p[0], errMsg)
 			continue
 		}
-		if p[0] == "node.hostname" {
+		if p[0] == "node.role" && p[1] == "worker" {
+			placement["node-role.kubernetes.io/worker"] = "true"
+		} else if p[0] == "node.role" && p[1] == "manager" {
+			placement["node-role.kubernetes.io/master"] = "true"
+		} else if p[0] == "node.hostname" {
 			placement["kubernetes.io/hostname"] = p[1]
 		} else if p[0] == "engine.labels.operatingsystem" {
 			placement["beta.kubernetes.io/os"] = p[1]


### PR DESCRIPTION
This PR adds support for `node.role == manager` and `node.role == worker` placement labels, as described here: https://docs.docker.com/engine/reference/commandline/service_create/#specify-service-constraints-constraint#specify-service-constraints---constraint

The following labels are created:
```
node.role == worker => node-role.kubernetes.io/worker: true
node.role == manager => node-role.kubernetes.io/master: true
```
