### PR TITLE
add warning that tells why the service is not created

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1176,6 +1176,8 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 			if service.ServiceType == "Headless" {
 				svc := k.CreateHeadlessService(name, service, objects)
 				objects = append(objects, svc)
+			} else {
+				log.Warnf("Service %q won't be created because 'ports' is not specified", name)
 			}
 		}
 


### PR DESCRIPTION
Hi all,

First off, thanks for providing this great tool!
But, I've found a point I want to improve, so let me report it with a patch.

---

Assuming a well-known port and most middlewares whose ports are EXPOSEed in docker image, we often omits the ports directive in docker-compose.yml.

And when converting such docker-compose.yml to k8s manifests by kompose, the creation of service is implicitly skipped.
I know that mentioning about ports exists in the Label section: https://kompose.io/user-guide/#labels

I don't think this behavior is irrational, but on the other hand, I'm thinking it useful to be more explicit about this behavior for k8s beginners.

This patch makes kompose print a warning if no ports are specified and it is not Headless.

I don't stick to this way, but hope that the behavior about this issue will be improved.
Thanks,