### PR TITLE
make kompose exit with 1 if error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -87,12 +85,10 @@ var RootCmd = &cobra.Command{
 	},
 }
 
-// Execute TODO: comment
-func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(-1)
-	}
+// Execute executes the root level command.
+// It returns an erorr if any.
+func Execute() error {
+	return RootCmd.Execute()
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -16,8 +16,15 @@ limitations under the License.
 
 package main
 
-import "github.com/kubernetes/kompose/cmd"
+import (
+	"log"
+
+	"github.com/kubernetes/kompose/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		log.SetFlags(0)
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Old code passes -1 to os.Exit and the value is directly passed to syscall.
The behavior with -1 depends on environments (most cases should convert
into 255 though)

This commit removes unnecessary the ambiguity and changes it to use 1 instead of 255.

---
Also, this change is in favor of https://golang.org/pkg/os/#Exit:

```
For portability, the status code should be in the range [0, 125].
```