### PR TITLE
Create directories if --out ends with "/" or includes nonexistent directories

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -173,7 +173,6 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 		if err := os.MkdirAll(opt.OutFile, os.ModePerm); err != nil {
 			return errors.Wrap(err, "failed to create a directory")
 		}
-		log.Printf("Output directory %q created", opt.OutFile)
 	}
 
 	// Check if output file is a directory

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -162,23 +162,18 @@ func objectToRaw(object runtime.Object) runtime.RawExtension {
 
 }
 
-func fileExists(p string) bool {
-	_, err := os.Stat(p)
-	return err == nil
-}
-
 // PrintList will take the data converted and decide on the commandline attributes given
 func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 	var f *os.File
 	dirName := getDirName(opt)
 	log.Debugf("Target Dir: %s", dirName)
 
-	// Create a directory if "out" ends with "/".
-	if !fileExists(opt.OutFile) && strings.HasSuffix(opt.OutFile, "/") {
+	// Create a directory if "out" ends with "/" and does not exist.
+	if !transformer.Exists(opt.OutFile) && strings.HasSuffix(opt.OutFile, "/") {
 		if err := os.MkdirAll(opt.OutFile, os.ModePerm); err != nil {
 			return errors.Wrap(err, "failed to create a directory")
 		}
-		log.Infof("Output directory %q created", opt.OutFile)
+		log.Printf("Output directory %q created", opt.OutFile)
 	}
 
 	// Check if output file is a directory
@@ -194,6 +189,7 @@ func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "transformer.CreateOutFile failed")
 		}
+		log.Printf("Kubernetes file %q created", opt.OutFile)
 		defer f.Close()
 	}
 

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -162,12 +162,24 @@ func objectToRaw(object runtime.Object) runtime.RawExtension {
 
 }
 
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
 // PrintList will take the data converted and decide on the commandline attributes given
 func PrintList(objects []runtime.Object, opt kobject.ConvertOptions) error {
-
 	var f *os.File
 	dirName := getDirName(opt)
 	log.Debugf("Target Dir: %s", dirName)
+
+	// Create a directory if "out" ends with "/".
+	if !fileExists(opt.OutFile) && strings.HasSuffix(opt.OutFile, "/") {
+		if err := os.MkdirAll(opt.OutFile, os.ModePerm); err != nil {
+			return errors.Wrap(err, "failed to create a directory")
+		}
+		log.Infof("Output directory %q created", opt.OutFile)
+	}
 
 	// Check if output file is a directory
 	isDirVal, err := isDir(opt.OutFile)

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -49,7 +49,7 @@ func CreateOutFile(out string) (*os.File, error) {
 	if len(out) == 0 {
 		return nil, nil
 	}
-	// Creates directories if "out" contains unexistent directories.
+	// Creates directories if "out" contains nonexistent directories.
 	if dir := filepath.Dir(out); !Exists(dir) {
 		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 			return nil, errors.Wrap(err, "failed to create directories")

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -531,8 +531,6 @@ sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/f
 convert::expect_success "$cmd" "/tmp/output-oc.json"
 
 
-
-
 ######
 # Test the output file behavior of kompose convert
 # Default behavior without -o
@@ -543,6 +541,10 @@ convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixture
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR -j" "$TEMP_DIR/redis-deployment.json" "$TEMP_DIR/redis-service.json" "$TEMP_DIR/web-deployment.json" "$TEMP_DIR/web-service.json"
 # Behavior with -o <dirname>/<filename>
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_file -j" "$TEMP_DIR/output_file"
+# Behavior with -o <non-existent-dirname>/
+ls -al $TEMP_DIR
+dst=$TEMP_DIR/output_dir/
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $dst -j" "${dst}redis-deployment.json" "${dst}redis-service.json" "${dst}web-deployment.json" "${dst}web-service.json"
 
 ######
 # Test charts generate with custom dir

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -542,9 +542,10 @@ convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixture
 # Behavior with -o <dirname>/<filename>
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_file -j" "$TEMP_DIR/output_file"
 # Behavior with -o <non-existent-dirname>/
-ls -al $TEMP_DIR
 dst=$TEMP_DIR/output_dir/
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $dst -j" "${dst}redis-deployment.json" "${dst}redis-service.json" "${dst}web-deployment.json" "${dst}web-service.json"
+# Behavior with -o <non-existent-dirname>/<filename>
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_dir2/output_file -j" "$TEMP_DIR/output_dir2/output_file"
 
 ######
 # Test charts generate with custom dir

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -530,23 +530,6 @@ cmd="kompose --provider openshift -f $KOMPOSE_ROOT/script/test/fixtures/service-
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/service-label/output-oc.json > /tmp/output-oc.json
 convert::expect_success "$cmd" "/tmp/output-oc.json"
 
-
-######
-# Test the output file behavior of kompose convert
-# Default behavior without -o
-convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -j" "redis-deployment.json" "redis-service.json" "web-deployment.json" "web-service.json"
-# Behavior with -o <filename>
-convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o output_file -j" "output_file"
-# Behavior with -o <dirname>
-convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR -j" "$TEMP_DIR/redis-deployment.json" "$TEMP_DIR/redis-service.json" "$TEMP_DIR/web-deployment.json" "$TEMP_DIR/web-service.json"
-# Behavior with -o <dirname>/<filename>
-convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_file -j" "$TEMP_DIR/output_file"
-# Behavior with -o <non-existent-dirname>/
-dst=$TEMP_DIR/output_dir/
-convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $dst -j" "${dst}redis-deployment.json" "${dst}redis-service.json" "${dst}web-deployment.json" "${dst}web-service.json"
-# Behavior with -o <non-existent-dirname>/<filename>
-convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_dir2/output_file -j" "$TEMP_DIR/output_dir2/output_file"
-
 ######
 # Test charts generate with custom dir
 convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR -j -c" "$TEMP_DIR/Chart.yaml" "$TEMP_DIR/README.md" "$TEMP_DIR/templates/redis-deployment.json" "$TEMP_DIR/templates/redis-service.json" "$TEMP_DIR/templates/web-deployment.json" "$TEMP_DIR/templates/web-service.json"

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -63,5 +63,18 @@ os_output="$KOMPOSE_ROOT/script/test/fixtures/$DIR/output-os.json"
 convert::expect_success_and_warning "$k8s_cmd" "$k8s_output"
 convert::expect_success_and_warning "$os_cmd" "$os_output"
 
-
-
+######
+# Test the output file behavior of kompose convert
+# Default behavior without -o
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -j" "redis-deployment.json" "redis-service.json" "web-deployment.json" "web-service.json"
+# Behavior with -o <filename>
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o output_file -j" "output_file"
+# Behavior with -o <dirname>
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR -j" "$TEMP_DIR/redis-deployment.json" "$TEMP_DIR/redis-service.json" "$TEMP_DIR/web-deployment.json" "$TEMP_DIR/web-service.json"
+# Behavior with -o <dirname>/<filename>
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_file -j" "$TEMP_DIR/output_file"
+# Behavior with -o <non-existent-dirname>/
+dst=$TEMP_DIR/output_dir/
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $dst -j" "${dst}redis-deployment.json" "${dst}redis-service.json" "${dst}web-deployment.json" "${dst}web-service.json"
+# Behavior with -o <non-existent-dirname>/<filename>
+convert::check_artifacts_generated "kompose -f $KOMPOSE_ROOT/script/test/fixtures/redis-example/docker-compose.yml convert -o $TEMP_DIR/output_dir2/output_file -j" "$TEMP_DIR/output_dir2/output_file"


### PR DESCRIPTION
Ref #1265

---

While I was trying kompose, I was surprised a bit that the kompose didn't create the destination directory automatically.
This change does not change the current behavior drastically, but makes kompose create directories if the given path (--out) ends with `/` and the directory does not exist.