### PR TITLE
Add liveness and readiness control by label

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -157,6 +157,8 @@ type HealthCheck struct {
 	Retries     int32
 	StartPeriod int32
 	Disable     bool
+	Readiness   bool
+	Liveness    bool
 }
 
 // EnvVar holds the environment variable struct of a container

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -44,6 +44,10 @@ const (
 	LabelImagePullSecret = "kompose.image-pull-secret"
 	// LabelImagePullPolicy defines Kubernetes PodSpec imagePullPolicy.
 	LabelImagePullPolicy = "kompose.image-pull-policy"
+	// HealthCheckLiveness define if will create a liveness healthcheck
+	HealthCheckLiveness = "kompose.service.healthcheck.liveness"
+	// HealthCheckReadiness Define if will create a readiness healthcheck
+	HealthCheckReadiness = "kompose.service.healthcheck.readiness"
 
 	// ServiceTypeHeadless ...
 	ServiceTypeHeadless = "Headless"

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -516,6 +516,10 @@ func parseKomposeLabels(labels map[string]string, serviceConfig *kobject.Service
 			serviceConfig.ImagePullSecret = value
 		case LabelImagePullPolicy:
 			serviceConfig.ImagePullPolicy = value
+		case HealthCheckLiveness:
+			serviceConfig.HealthChecks.Liveness = cast.ToBool(value)
+		case HealthCheckReadiness:
+			serviceConfig.HealthChecks.Readiness = cast.ToBool(value)
 		default:
 			serviceConfig.Labels[key] = value
 		}

--- a/pkg/testutils/kubernetes.go
+++ b/pkg/testutils/kubernetes.go
@@ -2,6 +2,8 @@ package testutils
 
 import (
 	"errors"
+
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -16,6 +18,28 @@ func CheckForHeadless(objects []runtime.Object) error {
 			// Check if it is a headless services
 			if svc.Spec.ClusterIP != "None" {
 				return errors.New("this is not a Headless services")
+			}
+		}
+	}
+	if !serviceCreated {
+		return errors.New("no Service created")
+	}
+	return nil
+}
+
+// CheckForHealthCheckLivenessAndReadiness check if has liveness and readiness in healthcheck configured.
+func CheckForHealthCheckLivenessAndReadiness(objects []runtime.Object) error {
+	serviceCreated := false
+	for _, obj := range objects {
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			serviceCreated = true
+
+			// Check if it is a headless services
+			if deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.Exec == nil {
+				return errors.New("there is not a ReadinessProbe")
+			}
+			if deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Exec == nil {
+				return errors.New("there is not a LivenessGate")
 			}
 		}
 	}

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -532,7 +532,18 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 			// to compose. Once the feature has been implemented, this will automatically work
 			probe.InitialDelaySeconds = service.HealthChecks.StartPeriod
 
-			template.Spec.Containers[0].LivenessProbe = &probe
+			// If there is a healthcheck, then at least liveness should be enabled
+			if service.HealthChecks.Liveness == false && service.HealthChecks.Readiness == false {
+				service.HealthChecks.Liveness = true
+			}
+
+			if service.HealthChecks.Liveness == true {
+				template.Spec.Containers[0].LivenessProbe = &probe
+			}
+			if service.HealthChecks.Readiness == true {
+				template.Spec.Containers[0].ReadinessProbe = &probe
+			}
+
 		}
 
 		if service.StopGracePeriod != "" {

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -382,6 +382,38 @@ func TestServiceWithoutPort(t *testing.T) {
 
 }
 
+// TestServiceWithoutPort this tests if Headless Service is created for services without Port.
+func TestServiceWithHealthCheck(t *testing.T) {
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		ServiceType:   "Headless",
+		HealthChecks: kobject.HealthCheck{
+			Test:        []string{"arg1", "arg2"},
+			Timeout:     10,
+			Interval:    5,
+			Retries:     3,
+			StartPeriod: 60,
+			Readiness:   true,
+			Liveness:    true,
+		},
+	}
+
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+
+	objects, err := k.Transform(komposeObject, kobject.ConvertOptions{CreateD: true, Replicas: 1})
+	if err != nil {
+		t.Error(errors.Wrap(err, "k.Transform failed"))
+	}
+	if err := testutils.CheckForHealthCheckLivenessAndReadiness(objects); err != nil {
+		t.Error(err)
+	}
+
+}
+
 // Tests if deployment strategy is being set to Recreate when volumes are
 // present
 func TestRecreateStrategyWithVolumesPresent(t *testing.T) {


### PR DESCRIPTION
Related: https://github.com/kubernetes/kompose/issues/1262

Allow the liveness and readiness control by label like:

The following `docker-compose.yml`
```yaml
...
    labels:
      kompose.service.healthcheck.liveness: "true"
      kompose.service.healthcheck.readiness: "true"
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost/health"]
      interval: 5s
      timeout: 5s
      retries: 3
      start_period: 120s
```

generates the `deployment.yml`:
```yaml
           livenessProbe:
             exec:
               command:
                 - curl
                 - -f
                 - http://localhost/health
             failureThreshold: 3
             initialDelaySeconds: 120
             periodSeconds: 5
             timeoutSeconds: 5
           readinessProbe:
             exec:
               command:
                 - curl
                 - -f
                 - http://localhost/health
             failureThreshold: 3
             initialDelaySeconds: 120
             periodSeconds: 5
             timeoutSeconds: 5
```