### PR TITLE
Add readiness healthcheck generation by label

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -137,7 +137,7 @@ type ServiceConfig struct {
 	GroupAdd           []int64                     `compose:"group_add"`
 	Volumes            []Volumes                   `compose:""`
 	Secrets            []dockerCliTypes.ServiceSecretConfig
-	HealthChecks       HealthCheck       `compose:""`
+	HealthChecks       HealthChecks      `compose:""`
 	Placement          map[string]string `compose:""`
 	//This is for long LONG SYNTAX link(https://docs.docker.com/compose/compose-file/#long-syntax)
 	Configs []dockerCliTypes.ServiceConfigObjConfig `compose:""`
@@ -145,6 +145,12 @@ type ServiceConfig struct {
 	ConfigsMetaData map[string]dockerCliTypes.ConfigObjConfig `compose:""`
 
 	WithKomposeAnnotation bool `compose:""`
+}
+
+// HealthChecks used to distinguish between liveness and readiness
+type HealthChecks struct {
+	Liveness  HealthCheck
+	Readiness HealthCheck
 }
 
 // HealthCheck the healthcheck configuration for a service

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -44,6 +44,18 @@ const (
 	LabelImagePullSecret = "kompose.image-pull-secret"
 	// LabelImagePullPolicy defines Kubernetes PodSpec imagePullPolicy.
 	LabelImagePullPolicy = "kompose.image-pull-policy"
+	// HealthCheckReadinessDisable defines readiness health check disable
+	HealthCheckReadinessDisable = "kompose.service.healthcheck.readiness.disable"
+	// HealthCheckReadinessTest defines readiness health check test
+	HealthCheckReadinessTest = "kompose.service.healthcheck.readiness.test"
+	// HealthCheckReadinessInterval defines readiness health check interval
+	HealthCheckReadinessInterval = "kompose.service.healthcheck.readiness.interval"
+	// HealthCheckReadinessTimeout defines readiness health check timeout
+	HealthCheckReadinessTimeout = "kompose.service.healthcheck.readiness.timeout"
+	// HealthCheckReadinessRetries defines readiness health check retries
+	HealthCheckReadinessRetries = "kompose.service.healthcheck.readiness.retries"
+	// HealthCheckReadinessStartPeriod defines readiness health check start period
+	HealthCheckReadinessStartPeriod = "kompose.service.healthcheck.readiness.start_period"
 
 	// ServiceTypeHeadless ...
 	ServiceTypeHeadless = "Headless"

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -389,8 +389,8 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 
 		// HealthCheck Readiness
 		var readiness, errReadiness = parseHealthCheckReadiness(*&composeServiceConfig.Labels)
-		if !readiness.Disable {
-			serviceConfig.HealthChecks.Readiness, errReadiness = parseHealthCheckReadiness(*&composeServiceConfig.Labels)
+		if readiness.Test != nil && len(readiness.Test) > 0 && len(readiness.Test[0]) > 0 && !readiness.Disable {
+			serviceConfig.HealthChecks.Readiness = readiness
 			if errReadiness != nil {
 				return kobject.KomposeObject{}, errors.Wrap(errReadiness, "Unable to parse health check")
 			}

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -34,6 +34,7 @@ import (
 
 	"fmt"
 
+	shlex "github.com/google/shlex"
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -233,7 +234,7 @@ a Kubernetes-compatible format.
 */
 func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error) {
 
-	var test string
+	var test []string
 	var timeout, interval, retries, startPeriod int32
 	var disable bool
 
@@ -242,7 +243,7 @@ func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error)
 		case HealthCheckReadinessDisable:
 			disable = cast.ToBool(value)
 		case HealthCheckReadinessTest:
-			test = value
+			test, _ = shlex.Split(value)
 		case HealthCheckReadinessInterval:
 			parse, err := time.ParseDuration(value)
 			if err != nil {
@@ -268,9 +269,7 @@ func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error)
 
 	// Due to docker/cli adding "CMD-SHELL" to the struct, we remove the first element of composeHealthCheck.Test
 	return kobject.HealthCheck{
-		Test: types.HealthCheckTest{
-			test,
-		},
+		Test:        test[1:],
 		Timeout:     timeout,
 		Interval:    interval,
 		Retries:     retries,

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -270,9 +270,17 @@ func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error)
 		}
 	}
 
+	if test[0] == "NONE" {
+		disable = true
+		test = test[1:]
+	}
+	if test[0] == "CMD" || test[0] == "CMD-SHELL" {
+		test = test[1:]
+	}
+
 	// Due to docker/cli adding "CMD-SHELL" to the struct, we remove the first element of composeHealthCheck.Test
 	return kobject.HealthCheck{
-		Test:        test[1:],
+		Test:        test,
 		Timeout:     timeout,
 		Interval:    interval,
 		Retries:     retries,

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -234,7 +234,8 @@ a Kubernetes-compatible format.
 */
 func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error) {
 
-	var test []string
+	// initialize with CMD as default to not break at return (will be ignored if no test is informed)
+	test := []string{"CMD"}
 	var timeout, interval, retries, startPeriod int32
 	var disable bool
 
@@ -243,7 +244,9 @@ func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error)
 		case HealthCheckReadinessDisable:
 			disable = cast.ToBool(value)
 		case HealthCheckReadinessTest:
-			test, _ = shlex.Split(value)
+			if len(value) > 0 {
+				test, _ = shlex.Split(value)
+			}
 		case HealthCheckReadinessInterval:
 			parse, err := time.ParseDuration(value)
 			if err != nil {

--- a/pkg/testutils/kubernetes.go
+++ b/pkg/testutils/kubernetes.go
@@ -2,6 +2,8 @@ package testutils
 
 import (
 	"errors"
+
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -16,6 +18,28 @@ func CheckForHeadless(objects []runtime.Object) error {
 			// Check if it is a headless services
 			if svc.Spec.ClusterIP != "None" {
 				return errors.New("this is not a Headless services")
+			}
+		}
+	}
+	if !serviceCreated {
+		return errors.New("no Service created")
+	}
+	return nil
+}
+
+// CheckForHealthCheckLivenessAndReadiness check if has liveness and readiness in healthcheck configured.
+func CheckForHealthCheckLivenessAndReadiness(objects []runtime.Object) error {
+	serviceCreated := false
+	for _, obj := range objects {
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			serviceCreated = true
+
+			// Check if it is a headless services
+			if deployment.Spec.Template.Spec.Containers[0].ReadinessProbe == nil {
+				return errors.New("there is not a ReadinessProbe")
+			}
+			if deployment.Spec.Template.Spec.Containers[0].LivenessProbe == nil {
+				return errors.New("there is not a LivenessGate")
 			}
 		}
 	}

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -510,29 +510,52 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		template.Spec.NodeSelector = service.Placement
 		// Configure the HealthCheck
 		// We check to see if it's blank
-		if !reflect.DeepEqual(service.HealthChecks, kobject.HealthCheck{}) {
+		if !reflect.DeepEqual(service.HealthChecks.Liveness, kobject.HealthCheck{}) {
 			probe := api.Probe{}
 
-			if len(service.HealthChecks.Test) > 0 {
+			if len(service.HealthChecks.Liveness.Test) > 0 {
 				probe.Handler = api.Handler{
 					Exec: &api.ExecAction{
-						Command: service.HealthChecks.Test,
+						Command: service.HealthChecks.Liveness.Test,
 					},
 				}
 			} else {
 				return errors.New("Health check must contain a command")
 			}
 
-			probe.TimeoutSeconds = service.HealthChecks.Timeout
-			probe.PeriodSeconds = service.HealthChecks.Interval
-			probe.FailureThreshold = service.HealthChecks.Retries
+			probe.TimeoutSeconds = service.HealthChecks.Liveness.Timeout
+			probe.PeriodSeconds = service.HealthChecks.Liveness.Interval
+			probe.FailureThreshold = service.HealthChecks.Liveness.Retries
 
 			// See issue: https://github.com/docker/cli/issues/116
 			// StartPeriod has been added to docker/cli however, it is not yet added
 			// to compose. Once the feature has been implemented, this will automatically work
-			probe.InitialDelaySeconds = service.HealthChecks.StartPeriod
+			probe.InitialDelaySeconds = service.HealthChecks.Liveness.StartPeriod
 
 			template.Spec.Containers[0].LivenessProbe = &probe
+		}
+		if !reflect.DeepEqual(service.HealthChecks.Readiness, kobject.HealthCheck{}) {
+			probeHealthCheckReadiness := api.Probe{}
+			if len(service.HealthChecks.Readiness.Test) > 0 {
+				probeHealthCheckReadiness.Handler = api.Handler{
+					Exec: &api.ExecAction{
+						Command: service.HealthChecks.Readiness.Test,
+					},
+				}
+			} else {
+				return errors.New("Health check must contain a command")
+			}
+
+			probeHealthCheckReadiness.TimeoutSeconds = service.HealthChecks.Readiness.Timeout
+			probeHealthCheckReadiness.PeriodSeconds = service.HealthChecks.Readiness.Interval
+			probeHealthCheckReadiness.FailureThreshold = service.HealthChecks.Readiness.Retries
+
+			// See issue: https://github.com/docker/cli/issues/116
+			// StartPeriod has been added to docker/cli however, it is not yet added
+			// to compose. Once the feature has been implemented, this will automatically work
+			probeHealthCheckReadiness.InitialDelaySeconds = service.HealthChecks.Readiness.StartPeriod
+
+			template.Spec.Containers[0].ReadinessProbe = &probeHealthCheckReadiness
 		}
 
 		if service.StopGracePeriod != "" {

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -360,6 +360,45 @@ func TestIsDir(t *testing.T) {
 }
 
 // TestServiceWithoutPort this tests if Headless Service is created for services without Port.
+func TestServiceWithHealthCheck(t *testing.T) {
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		ServiceType:   "Headless",
+		HealthChecks: kobject.HealthChecks{
+			Readiness: kobject.HealthCheck{
+				Test:        []string{"arg1", "arg2"},
+				Timeout:     10,
+				Interval:    5,
+				Retries:     3,
+				StartPeriod: 60,
+			},
+			Liveness: kobject.HealthCheck{
+				Test:        []string{"arg1", "arg2"},
+				Timeout:     11,
+				Interval:    6,
+				Retries:     4,
+				StartPeriod: 61,
+			},
+		},
+	}
+
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+
+	objects, err := k.Transform(komposeObject, kobject.ConvertOptions{CreateD: true, Replicas: 1})
+	if err != nil {
+		t.Error(errors.Wrap(err, "k.Transform failed"))
+	}
+	if err := testutils.CheckForHealthCheckLivenessAndReadiness(objects); err != nil {
+		t.Error(err)
+	}
+
+}
+
+// TestServiceWithoutPort this tests if Headless Service is created for services without Port.
 func TestServiceWithoutPort(t *testing.T) {
 	service := kobject.ServiceConfig{
 		ContainerName: "name",


### PR DESCRIPTION
Related: https://github.com/kubernetes/kompose/issues/1262

Allow the readiness healthcheck to be configured independent from the docker-compose healthcheck (liveness).

The following `docker-compose.yml`
```yaml
version: "3.4"

services:

  some-service:
    image: busybox:latest
    labels:
      kompose.service.healthcheck.readiness.test: CMD curl -f "http://localhost/health one-parameter"
      kompose.service.healthcheck.readiness.interval: 10s
      kompose.service.healthcheck.readiness.timeout: 10s
      kompose.service.healthcheck.readiness.retries: 3
      kompose.service.healthcheck.readiness.start_period: 120s
    healthcheck:
      test: "curl -f http://localhost/health"
      interval: 5s
      timeout: 5s
      retries: 5
      start_period: 120s
    ports:
      - "80:80"
      - "443:443"
```

generates the `deployment.yml`:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    kompose.cmd: kompose.exe convert -f docker-compose.yml
    kompose.service.healthcheck.readiness.interval: 10s
    kompose.service.healthcheck.readiness.retries: "3"
    kompose.service.healthcheck.readiness.start_period: 120s
    kompose.service.healthcheck.readiness.test: CMD curl -f "http://localhost/health one-parameter"
    kompose.service.healthcheck.readiness.timeout: 10s
    kompose.version: 1.22.0 (HEAD)
  creationTimestamp: null
  labels:
    io.kompose.service: some-service
  name: some-service
spec:
  replicas: 1
  selector:
    matchLabels:
      io.kompose.service: some-service
  strategy: {}
  template:
    metadata:
      annotations:
        kompose.cmd: kompose.exe convert -f docker-compose.yml
        kompose.service.healthcheck.readiness.interval: 10s
        kompose.service.healthcheck.readiness.retries: "3"
        kompose.service.healthcheck.readiness.start_period: 120s
        kompose.service.healthcheck.readiness.test: CMD curl -f "http://localhost/health one-parameter"
        kompose.service.healthcheck.readiness.timeout: 10s
        kompose.version: 1.22.0 (HEAD)
      creationTimestamp: null
      labels:
        io.kompose.service: some-service
    spec:
      containers:
        - image: busybox:latest
          livenessProbe:
            exec:
              command:
                - curl
                - -f
                - http://localhost/health
            failureThreshold: 5
            initialDelaySeconds: 120
            periodSeconds: 5
            timeoutSeconds: 5
          name: some-service
          ports:
            - containerPort: 80
            - containerPort: 443
          readinessProbe:
            exec:
              command:
                - curl
                - -f
                - http://localhost/health one-parameter
            failureThreshold: 3
            initialDelaySeconds: 120
            periodSeconds: 10
            timeoutSeconds: 10
          resources: {}
      restartPolicy: Always
status: {}
```

This way, if wanted, both readiness and liveness can be configured.