### PR TITLE
Fixed, #1385

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -165,6 +165,13 @@ The currently supported options are:
 | kompose.controller.type | deployment / daemonset / replicationcontroller |
 | kompose.image-pull-policy | kubernetes pods imagePullPolicy |
 | kompose.image-pull-secret | kubernetes secret name for imagePullSecrets |
+| kompose.service.healthcheck.readiness.test | kubernetes readiness exec command |
+| kompose.service.healthcheck.readiness.interval | kubernetes readiness interval value |
+| kompose.service.healthcheck.readiness.timeout | kubernetes readiness timeout value |
+| kompose.service.healthcheck.readiness.retries | kubernetes readiness retries value |
+| kompose.service.healthcheck.readiness.start_period | kubernetes readiness start_period |
+| kompose.service.healthcheck.liveness.http_get_path | kubernetes liveness httpGet path |
+| kompose.service.healthcheck.liveness.http_get_port | kubernetes liveness httpGet port |
 
 **Note**: `kompose.service.type` label should be defined with `ports` only (except for headless service), otherwise `kompose` will fail.
 
@@ -288,6 +295,42 @@ services:
     labels:
       kompose.image-pull-policy: "Never"
 ```
+
+
+For example:
+
+```yaml
+version: '2'
+services:
+  example-service:
+    image: example-image
+    labels:
+      kompose.service.healthcheck.liveness.http_get_path: /health/ping
+      kompose.service.healthcheck.liveness.http_get_port: 8080
+    healthcheck:
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+```
+
+- `kompose.service.healthcheck.liveness` defines Kubernetes [liveness HttpRequest](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request), If you use healthcheck without liveness labels, have to define `test` in healcheck it's work to Kubernetes [liveness command](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)
+
+For example:
+
+```yaml
+version: '2'
+services:
+  example-service:
+    image: example-image
+    labels:
+      kompose.service.healthcheck.readiness.test: CMD curl -f "http://localhost:8080/health/ping"
+      kompose.service.healthcheck.readiness.interval: 10s
+      kompose.service.healthcheck.readiness.timeout: 10s
+      kompose.service.healthcheck.readiness.retries: 3
+      kompose.service.healthcheck.readiness.start_period: 30s
+```
+- `kompose.service.healthcheck.readiness` defines Kubernetes [readiness](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)
 
 ## Restart
 

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -164,8 +164,8 @@ type HealthCheck struct {
 	Retries     int32
 	StartPeriod int32
 	Disable     bool
-	HttpPath    string
-	HttpPort    int32
+	HTTPPath    string
+	HTTPPort    int32
 }
 
 // EnvVar holds the environment variable struct of a container

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -164,6 +164,8 @@ type HealthCheck struct {
 	Retries     int32
 	StartPeriod int32
 	Disable     bool
+	HttpPath    string
+	HttpPort    int32
 }
 
 // EnvVar holds the environment variable struct of a container

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -76,14 +76,14 @@ func TestParseHttpHealthCheck(t *testing.T) {
 		StartPeriod: durationTypesPtr(3 * time.Second),
 	}
 	label := types.Labels{
-		HealthCheckLivenessHttpGetPath: "ping",
-		HealthCheckLivenessHttpGetPort: "80",
+		HealthCheckLivenessHTTPGetPath: "ping",
+		HealthCheckLivenessHTTPGetPort: "80",
 	}
 
 	// CMD-SHELL or SHELL is included Test within docker/cli, thus we remove the first value in Test
 	expected := kobject.HealthCheck{
-		HttpPath:    "ping",
-		HttpPort:    80,
+		HTTPPath:    "ping",
+		HTTPPort:    80,
 		Timeout:     1,
 		Interval:    2,
 		Retries:     2,

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -57,7 +57,39 @@ func TestParseHealthCheck(t *testing.T) {
 		Retries:     2,
 		StartPeriod: 3,
 	}
-	output, err := parseHealthCheck(check)
+	output, err := parseHealthCheck(check, nil)
+	if err != nil {
+		t.Errorf("Unable to convert HealthCheckConfig: %s", err)
+	}
+
+	if !reflect.DeepEqual(output, expected) {
+		t.Errorf("Structs are not equal, expected: %v, output: %v", expected, output)
+	}
+}
+
+func TestParseHttpHealthCheck(t *testing.T) {
+	helperValue := uint64(2)
+	check := types.HealthCheckConfig{
+		Timeout:     durationTypesPtr(1 * time.Second),
+		Interval:    durationTypesPtr(2 * time.Second),
+		Retries:     &helperValue,
+		StartPeriod: durationTypesPtr(3 * time.Second),
+	}
+	label := types.Labels{
+		HealthCheckLivenessHttpGetPath: "ping",
+		HealthCheckLivenessHttpGetPort: "80",
+	}
+
+	// CMD-SHELL or SHELL is included Test within docker/cli, thus we remove the first value in Test
+	expected := kobject.HealthCheck{
+		HttpPath:    "ping",
+		HttpPort:    80,
+		Timeout:     1,
+		Interval:    2,
+		Retries:     2,
+		StartPeriod: 3,
+	}
+	output, err := parseHealthCheck(check, label)
 	if err != nil {
 		t.Errorf("Unable to convert HealthCheckConfig: %s", err)
 	}

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -56,10 +56,10 @@ const (
 	HealthCheckReadinessRetries = "kompose.service.healthcheck.readiness.retries"
 	// HealthCheckReadinessStartPeriod defines readiness health check start period
 	HealthCheckReadinessStartPeriod = "kompose.service.healthcheck.readiness.start_period"
-	// HealthCheckLivenessHttpGetPath defines liveness health check HttpGet path
-	HealthCheckLivenessHttpGetPath = "kompose.service.healthcheck.liveness.http_get_path"
-	// HealthCheckLivenessHttpGetPort defines liveness health check HttpGet port
-	HealthCheckLivenessHttpGetPort = "kompose.service.healthcheck.liveness.http_get_port"
+	// HealthCheckLivenessHTTPGetPath defines liveness health check HttpGet path
+	HealthCheckLivenessHTTPGetPath = "kompose.service.healthcheck.liveness.http_get_path"
+	// HealthCheckLivenessHTTPGetPort defines liveness health check HttpGet port
+	HealthCheckLivenessHTTPGetPort = "kompose.service.healthcheck.liveness.http_get_port"
 
 	// ServiceTypeHeadless ...
 	ServiceTypeHeadless = "Headless"

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -56,6 +56,10 @@ const (
 	HealthCheckReadinessRetries = "kompose.service.healthcheck.readiness.retries"
 	// HealthCheckReadinessStartPeriod defines readiness health check start period
 	HealthCheckReadinessStartPeriod = "kompose.service.healthcheck.readiness.start_period"
+	// HealthCheckLivenessHttpGetPath defines liveness health check HttpGet path
+	HealthCheckLivenessHttpGetPath = "kompose.service.healthcheck.liveness.http_get_path"
+	// HealthCheckLivenessHttpGetPort defines liveness health check HttpGet port
+	HealthCheckLivenessHttpGetPort = "kompose.service.healthcheck.liveness.http_get_port"
 
 	// ServiceTypeHeadless ...
 	ServiceTypeHeadless = "Headless"

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -288,8 +288,11 @@ func parseHealthCheckReadiness(labels types.Labels) (kobject.HealthCheck, error)
 /* Convert the HealthCheckConfig as designed by Docker to
 a Kubernetes-compatible format.
 */
-func parseHealthCheck(composeHealthCheck types.HealthCheckConfig) (kobject.HealthCheck, error) {
+func parseHealthCheck(composeHealthCheck types.HealthCheckConfig, labels types.Labels) (kobject.HealthCheck, error) {
 	var timeout, interval, retries, startPeriod int32
+	var test []string
+	var httpPort int32
+	var httpPath string
 
 	// Here we convert the timeout from 1h30s (example) to 36030 seconds.
 	if composeHealthCheck.Timeout != nil {
@@ -320,9 +323,24 @@ func parseHealthCheck(composeHealthCheck types.HealthCheckConfig) (kobject.Healt
 		startPeriod = int32(parse.Seconds())
 	}
 
+	if composeHealthCheck.Test != nil {
+		test = composeHealthCheck.Test[1:]
+	}
+
+	for key, value := range labels {
+		switch key {
+		case HealthCheckLivenessHttpGetPath:
+			httpPath = value
+		case HealthCheckLivenessHttpGetPort:
+			httpPort = cast.ToInt32(value)
+		}
+	}
+
 	// Due to docker/cli adding "CMD-SHELL" to the struct, we remove the first element of composeHealthCheck.Test
 	return kobject.HealthCheck{
-		Test:        composeHealthCheck.Test[1:],
+		Test:        test,
+		HttpPath:    httpPath,
+		HttpPort:    httpPort,
 		Timeout:     timeout,
 		Interval:    interval,
 		Retries:     retries,
@@ -384,7 +402,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 		// HealthCheck Liveness
 		if composeServiceConfig.HealthCheck != nil && !composeServiceConfig.HealthCheck.Disable {
 			var err error
-			serviceConfig.HealthChecks.Liveness, err = parseHealthCheck(*composeServiceConfig.HealthCheck)
+			serviceConfig.HealthChecks.Liveness, err = parseHealthCheck(*composeServiceConfig.HealthCheck, *&composeServiceConfig.Labels)
 			if err != nil {
 				return kobject.KomposeObject{}, errors.Wrap(err, "Unable to parse health check")
 			}

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -329,9 +329,9 @@ func parseHealthCheck(composeHealthCheck types.HealthCheckConfig, labels types.L
 
 	for key, value := range labels {
 		switch key {
-		case HealthCheckLivenessHttpGetPath:
+		case HealthCheckLivenessHTTPGetPath:
 			httpPath = value
-		case HealthCheckLivenessHttpGetPort:
+		case HealthCheckLivenessHTTPGetPort:
 			httpPort = cast.ToInt32(value)
 		}
 	}
@@ -339,8 +339,8 @@ func parseHealthCheck(composeHealthCheck types.HealthCheckConfig, labels types.L
 	// Due to docker/cli adding "CMD-SHELL" to the struct, we remove the first element of composeHealthCheck.Test
 	return kobject.HealthCheck{
 		Test:        test,
-		HttpPath:    httpPath,
-		HttpPort:    httpPort,
+		HTTPPath:    httpPath,
+		HTTPPort:    httpPort,
 		Timeout:     timeout,
 		Interval:    interval,
 		Retries:     retries,

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"os"
 	"path"
 	"path/filepath"
@@ -45,6 +44,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 /**
@@ -512,13 +512,12 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 						Command: service.HealthChecks.Liveness.Test,
 					},
 				}
-
-			} else if !reflect.ValueOf(service.HealthChecks.Liveness.HttpPath).IsZero() &&
-				!reflect.ValueOf(service.HealthChecks.Liveness.HttpPort).IsZero() {
+			} else if !reflect.ValueOf(service.HealthChecks.Liveness.HTTPPath).IsZero() &&
+				!reflect.ValueOf(service.HealthChecks.Liveness.HTTPPort).IsZero() {
 				probe.Handler = api.Handler{
 					HTTPGet: &api.HTTPGetAction{
-						Path: service.HealthChecks.Liveness.HttpPath,
-						Port: intstr.FromInt(int(service.HealthChecks.Liveness.HttpPort)),
+						Path: service.HealthChecks.Liveness.HTTPPath,
+						Port: intstr.FromInt(int(service.HealthChecks.Liveness.HTTPPort)),
 					},
 				}
 			} else {

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"os"
 	"path"
 	"path/filepath"
@@ -509,6 +510,15 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 				probe.Handler = api.Handler{
 					Exec: &api.ExecAction{
 						Command: service.HealthChecks.Liveness.Test,
+					},
+				}
+
+			} else if !reflect.ValueOf(service.HealthChecks.Liveness.HttpPath).IsZero() &&
+				!reflect.ValueOf(service.HealthChecks.Liveness.HttpPort).IsZero() {
+				probe.Handler = api.Handler{
+					HTTPGet: &api.HTTPGetAction{
+						Path: service.HealthChecks.Liveness.HttpPath,
+						Port: intstr.FromInt(int(service.HealthChecks.Liveness.HttpPort)),
 					},
 				}
 			} else {


### PR DESCRIPTION
Support `HttpGet` at `Liveness` feature

docker-compose.yaml
```yaml
...
    labels:
      kompose.service.healthcheck.liveness.http_get_path: /health/ping
      kompose.service.healthcheck.liveness.http_get_port: 4444
    healthcheck:
      interval: 10s
      timeout: 10s
      retries: 3
      start_period: 30s
...
```

expected kompose convert 

```yaml
...
          livenessProbe:
            failureThreshold: 3
            httpGet:
              path: /health/ping
              port: 4444
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 10
...
```
