### PR TITLE
actually use normalizeNetworkNames to produce valid network names

### DIFF
--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -453,7 +453,7 @@ func TestNormalizeNetworkNames(t *testing.T) {
 		composeNetworkName    string
 		normalizedNetworkName string
 	}{
-		{"foo_bar", "foobar"},
+		{"foo_bar", "foo-bar"},
 		{"foo", "foo"},
 		{"FOO", "foo"},
 		{"foo.bar", "foo.bar"},

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -151,7 +151,7 @@ func normalizeVolumes(svcName string) string {
 }
 
 func normalizeNetworkNames(netName string) (string, error) {
-	netval := strings.ToLower(netName)
+	netval := strings.ToLower(strings.Replace(netName, "_", "-", -1))
 	regString := ("[^A-Za-z0-9.-]+")
 	reg, err := regexp.Compile(regString)
 	if err != nil {

--- a/pkg/loader/compose/v1v2.go
+++ b/pkg/loader/compose/v1v2.go
@@ -256,7 +256,14 @@ func libComposeToKomposeMapping(composeObject *project.Project) (kobject.Kompose
 			if len(composeServiceConfig.Networks.Networks) > 0 {
 				for _, value := range composeServiceConfig.Networks.Networks {
 					if value.Name != "default" {
-						serviceConfig.Network = append(serviceConfig.Network, value.RealName)
+						nomalizedNetworkName, err := normalizeNetworkNames(value.RealName)
+						if err != nil {
+							return kobject.KomposeObject{}, errors.Wrap(err, "Error trying to normalize network names")
+						}
+						if nomalizedNetworkName != value.RealName {
+							log.Warnf("Network name in docker-compose has been changed from %q to %q", value.RealName, nomalizedNetworkName)
+						}
+						serviceConfig.Network = append(serviceConfig.Network, nomalizedNetworkName)
 					}
 				}
 			}


### PR DESCRIPTION
Currently kompose does not normalize network names, which can lead to networks containing invalid characters for Kubernetes NetworkPolicy resources. There already was a function for this in ` pkg/loader/compose/utils.go`, but it was not used.