### PR TITLE
Fix the selector field of service resource

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -199,8 +199,9 @@ func (k *Kubernetes) InitSvc(name string, service kobject.ServiceConfig) *api.Se
 			Name:   name,
 			Labels: transformer.ConfigLabels(name),
 		},
+		// The selector uses the service.Name, which must be consistent with workloads label
 		Spec: api.ServiceSpec{
-			Selector: transformer.ConfigLabels(name),
+			Selector: transformer.ConfigLabels(service.Name),
 		},
 	}
 	return svc

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -38,6 +38,7 @@ import (
 
 func newServiceConfig() kobject.ServiceConfig {
 	return kobject.ServiceConfig{
+		Name:          "app",
 		ContainerName: "name",
 		Image:         "image",
 		Environment:   []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},

--- a/script/test/fixtures/v2/output-k8s.json
+++ b/script/test/fixtures/v2/output-k8s.json
@@ -172,7 +172,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-tcp"
+          "io.kompose.service": "redis"
         },
         "type": "LoadBalancer"
       },
@@ -203,7 +203,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-udp"
+          "io.kompose.service": "redis"
         },
         "type": "LoadBalancer"
       },

--- a/script/test/fixtures/v2/output-os.json
+++ b/script/test/fixtures/v2/output-os.json
@@ -172,7 +172,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-tcp"
+          "io.kompose.service": "redis"
         },
         "type": "LoadBalancer"
       },
@@ -203,7 +203,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-udp"
+          "io.kompose.service": "redis"
         },
         "type": "LoadBalancer"
       },


### PR DESCRIPTION
fix #1399 

一点小建议，因为没有详细的看过整个项目，可能不准确：我认为这个问题主要是原本在资源关系网中通用的 name 因为两种 svc，变为不通用。我建议可以将某个 name 作为关系网的不变值，例如 service.Name，而参数中的 `name string` 则可以成为每个资源自定义的 name。