### PR TITLE
fix kompose.image-pull-secret invalid when use compose configs

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -185,6 +185,14 @@ func (k *Kubernetes) InitPodSpecWithConfigMap(name string, image string, service
 		},
 		Volumes: volumes,
 	}
+
+	if service.ImagePullSecret != "" {
+		pod.ImagePullSecrets = []api.LocalObjectReference{
+			{
+				Name: service.ImagePullSecret,
+			},
+		}
+	}
 	return pod
 }
 

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -19,10 +19,11 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
-	dockerCliTypes "github.com/docker/cli/cli/compose/types"
 	"reflect"
 	"strings"
 	"testing"
+
+	dockerCliTypes "github.com/docker/cli/cli/compose/types"
 
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/kubernetes/kompose/pkg/loader/compose"


### PR DESCRIPTION
kompose version: 1.23.0 (bc7d9f4f)
compose version: 3.8

I found kompose.image-pull-secret will be invaild 
when compose service has configs
