### PR TITLE
Add support for placement preferences docker-compose v3.3+

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -215,6 +215,7 @@ type Volumes struct {
 type Placement struct {
 	PositiveConstraints map[string]string
 	NegativeConstraints map[string]string
+	Preferences         []string
 }
 
 // GetConfigMapKeyFromMeta ...

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -499,6 +499,11 @@ func TestCheckPlacementCustomLabels(t *testing.T) {
 			"node.labels.something == anything",
 			"node.labels.monitor != xxx",
 		},
+		Preferences: []types.PlacementPreferences{
+			{Spread: "node.labels.zone"},
+			{Spread: "foo"},
+			{Spread: "node.labels.ssd"},
+		},
 	}
 	output := loadV3Placement(placement)
 
@@ -509,10 +514,22 @@ func TestCheckPlacementCustomLabels(t *testing.T) {
 		NegativeConstraints: map[string]string{
 			"monitor": "xxx",
 		},
+		Preferences: []string{
+			"zone", "ssd",
+		},
 	}
 
 	checkConstraints(t, "positive", output.PositiveConstraints, expected.PositiveConstraints)
 	checkConstraints(t, "negative", output.NegativeConstraints, expected.NegativeConstraints)
+
+	if len(output.Preferences) != len(expected.Preferences) {
+		t.Errorf("preferences len is not equal, expected %d, got %d", len(expected.Preferences), len(output.Preferences))
+	}
+	for i := range output.Preferences {
+		if output.Preferences[i] != expected.Preferences[i] {
+			t.Errorf("preference is not equal, expected %s, got %s", expected.Preferences[i], output.Preferences[i])
+		}
+	}
 }
 
 func checkConstraints(t *testing.T, caseName string, output, expected map[string]string) {

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -138,8 +138,10 @@ func loadV3Placement(placement types.Placement) kobject.Placement {
 		PositiveConstraints: make(map[string]string),
 		NegativeConstraints: make(map[string]string),
 	}
+
+	// Convert constraints
 	equal, notEqual := " == ", " != "
-	errMsg := " constraints in placement is not supported, only 'node.hostname', 'engine.labels.operatingsystem' and 'node.labels.xxx' (ex: node.labels.something == anything) is supported as a constraint "
+	constraintsErrMsg := " constraints in placement is not supported, only 'node.hostname', 'engine.labels.operatingsystem' and 'node.labels.xxx' (ex: node.labels.something == anything) is supported as a constraint "
 	for _, j := range placement.Constraints {
 		operator := equal
 		if strings.Contains(j, notEqual) {
@@ -147,7 +149,7 @@ func loadV3Placement(placement types.Placement) kobject.Placement {
 		}
 		p := strings.Split(j, operator)
 		if len(p) < 2 {
-			log.Warn(p[0], errMsg)
+			log.Warn(p[0], constraintsErrMsg)
 			continue
 		}
 
@@ -159,7 +161,7 @@ func loadV3Placement(placement types.Placement) kobject.Placement {
 		} else if strings.HasPrefix(p[0], "node.labels.") {
 			key = strings.TrimPrefix(p[0], "node.labels.")
 		} else {
-			log.Warn(p[0], errMsg)
+			log.Warn(p[0], constraintsErrMsg)
 			continue
 		}
 
@@ -168,6 +170,17 @@ func loadV3Placement(placement types.Placement) kobject.Placement {
 		} else if operator == notEqual {
 			komposePlacement.NegativeConstraints[key] = p[1]
 		}
+	}
+
+	// Convert preferences
+	preferencesErrMsg := " preferences in placement is not supported, only 'node.labels.xxx'(ex: node.labels.something == anything) is supported as a preferences "
+	for _, p := range placement.Preferences {
+		if !strings.HasPrefix(p.Spread, "node.labels.") {
+			log.Warn(p.Spread, preferencesErrMsg)
+			continue
+		}
+		label := strings.TrimPrefix(p.Spread, "node.labels.")
+		komposePlacement.Preferences = append(komposePlacement.Preferences, label)
 	}
 	return komposePlacement
 }

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -137,6 +137,7 @@ func loadV3Placement(placement types.Placement) kobject.Placement {
 	komposePlacement := kobject.Placement{
 		PositiveConstraints: make(map[string]string),
 		NegativeConstraints: make(map[string]string),
+		Preferences:         make([]string, 0, len(placement.Preferences)),
 	}
 
 	// Convert constraints

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -533,6 +533,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		template.Spec.Containers[0].TTY = service.Tty
 		template.Spec.Volumes = append(template.Spec.Volumes, volumes...)
 		template.Spec.Affinity = ConfigAffinity(service)
+		template.Spec.TopologySpreadConstraints = ConfigTopologySpreadConstraints(service)
 		// Configure the HealthCheck
 		// We check to see if it's blank
 		if !reflect.DeepEqual(service.HealthChecks.Liveness, kobject.HealthCheck{}) {

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1078,10 +1078,7 @@ func ConfigTopologySpreadConstraints(service kobject.ServiceConfig) []api.Topolo
 			TopologyKey:       p,
 			WhenUnsatisfiable: api.ScheduleAnyway,
 			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{{
-					Key:      p,
-					Operator: metav1.LabelSelectorOpExists,
-				}},
+				MatchLabels: transformer.ConfigLabels(service.Name),
 			},
 		})
 	}

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1060,7 +1060,8 @@ func ConfigAffinity(service kobject.ServiceConfig) *api.Affinity {
 	}
 	// Config preferences
 	// Convert preferences to preferredDuringSchedulingIgnoredDuringExecution
-	if preferencesLen := len(service.Placement.Preferences); preferencesLen > 0 {
+	// Placement preferences are ignored for global services
+	if preferencesLen := len(service.Placement.Preferences); preferencesLen > 0 && service.DeployMode != "global" {
 		preferences := make([]api.PreferredSchedulingTerm, 0, preferencesLen)
 		for i, p := range service.Placement.Preferences {
 			preferences = append(preferences, api.PreferredSchedulingTerm{

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -593,7 +593,7 @@ func TestConfigAffinity(t *testing.T) {
 				},
 			},
 		},
-		"ConfigTopologySpreadConstraint (nil)": {
+		"ConfigAffinity (nil)": {
 			kobject.ServiceConfig{},
 			nil,
 		},

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -576,6 +576,9 @@ func TestConfigAffinity(t *testing.T) {
 					NegativeConstraints: map[string]string{
 						"baz": "qux",
 					},
+					Preferences: []string{
+						"zone", "ssd",
+					},
 				},
 			},
 			result: &api.Affinity{
@@ -586,6 +589,24 @@ func TestConfigAffinity(t *testing.T) {
 								MatchExpressions: []api.NodeSelectorRequirement{
 									{Key: "foo", Operator: api.NodeSelectorOpIn, Values: []string{"bar"}},
 									{Key: "baz", Operator: api.NodeSelectorOpNotIn, Values: []string{"qux"}},
+								},
+							},
+						},
+					},
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.PreferredSchedulingTerm{
+						{
+							Weight: 2,
+							Preference: api.NodeSelectorTerm{
+								MatchExpressions: []api.NodeSelectorRequirement{
+									{Key: "zone", Operator: api.NodeSelectorOpExists, Values: nil},
+								},
+							},
+						},
+						{
+							Weight: 1,
+							Preference: api.NodeSelectorTerm{
+								MatchExpressions: []api.NodeSelectorRequirement{
+									{Key: "ssd", Operator: api.NodeSelectorOpExists, Values: nil},
 								},
 							},
 						},

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -609,12 +609,14 @@ func TestConfigAffinity(t *testing.T) {
 }
 
 func TestConfigTopologySpreadConstraints(t *testing.T) {
+	serviceName := "app"
 	testCases := map[string]struct {
 		service kobject.ServiceConfig
 		result  []api.TopologySpreadConstraint
 	}{
 		"ConfigTopologySpreadConstraint": {
 			service: kobject.ServiceConfig{
+				Name: serviceName,
 				Placement: kobject.Placement{
 					Preferences: []string{
 						"zone", "ssd",
@@ -627,9 +629,7 @@ func TestConfigTopologySpreadConstraints(t *testing.T) {
 					TopologyKey:       "zone",
 					WhenUnsatisfiable: api.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: "zone", Operator: metav1.LabelSelectorOpExists},
-						},
+						MatchLabels: transformer.ConfigLabels(serviceName),
 					},
 				},
 				{
@@ -637,9 +637,7 @@ func TestConfigTopologySpreadConstraints(t *testing.T) {
 					TopologyKey:       "ssd",
 					WhenUnsatisfiable: api.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: "ssd", Operator: metav1.LabelSelectorOpExists},
-						},
+						MatchLabels: transformer.ConfigLabels(serviceName),
 					},
 				},
 			},

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -614,6 +614,15 @@ func TestConfigAffinity(t *testing.T) {
 				},
 			},
 		},
+		"ConfigAffinity (global service)": {
+			service: kobject.ServiceConfig{
+				DeployMode: "global",
+				Placement: kobject.Placement{
+					Preferences: []string{"zone"},
+				},
+			},
+			result: nil,
+		},
 		"ConfigAffinity (nil)": {
 			kobject.ServiceConfig{},
 			nil,

--- a/pkg/transformer/kubernetes/podspec.go
+++ b/pkg/transformer/kubernetes/podspec.go
@@ -335,6 +335,12 @@ func ServiceAccountName(serviceAccountName string) PodSpecOption {
 	}
 }
 
+func TopologySpreadConstraints(service kobject.ServiceConfig) PodSpecOption {
+	return func(podSpec *PodSpec) {
+		podSpec.TopologySpreadConstraints = ConfigTopologySpreadConstraints(service)
+	}
+}
+
 func (podSpec *PodSpec) Append(ops ...PodSpecOption) *PodSpec {
 	for _, option := range ops {
 		option(podSpec)

--- a/script/test/fixtures/deploy/placement/docker-compose-placement.yaml
+++ b/script/test/fixtures/deploy/placement/docker-compose-placement.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.3"
 services:
   redis:
     image: redis
@@ -11,3 +11,7 @@ services:
           - engine.labels.operatingsystem == ubuntu 14.04
           - node.labels.foo != bar
           - baz != qux
+        preferences:
+          - spread: node.labels.zone
+          - spread: foo
+          - spread: node.labels.ssd

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.json
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.json
@@ -91,7 +91,31 @@
                       ]
                     }
                   ]
-                }
+                },
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                  {
+                    "weight": 2,
+                    "preference": {
+                      "matchExpressions": [
+                        {
+                          "key": "zone",
+                          "operator": "Exists"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "weight": 1,
+                    "preference": {
+                      "matchExpressions": [
+                        {
+                          "key": "ssd",
+                          "operator": "Exists"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
           }

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.json
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.json
@@ -76,48 +76,58 @@
                         {
                           "key": "kubernetes.io/hostname",
                           "operator": "In",
-                          "values": ["machine"]
+                          "values": [
+                            "machine"
+                          ]
                         },
                         {
                           "key": "beta.kubernetes.io/os",
                           "operator": "In",
-                          "values": ["ubuntu 14.04"]
+                          "values": [
+                            "ubuntu 14.04"
+                          ]
                         },
                         {
                           "key": "foo",
                           "operator": "NotIn",
-                          "values": ["bar"]
+                          "values": [
+                            "bar"
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                "preferredDuringSchedulingIgnoredDuringExecution": [
-                  {
-                    "weight": 2,
-                    "preference": {
-                      "matchExpressions": [
-                        {
-                          "key": "zone",
-                          "operator": "Exists"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "weight": 1,
-                    "preference": {
-                      "matchExpressions": [
-                        {
-                          "key": "ssd",
-                          "operator": "Exists"
-                        }
-                      ]
-                    }
-                  }
-                ]
+                }
               }
-            }
+            },
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 2,
+                "topologyKey": "zone",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchExpressions": [
+                    {
+                      "key": "zone",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              },
+              {
+                "maxSkew": 1,
+                "topologyKey": "ssd",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchExpressions": [
+                    {
+                      "key": "ssd",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              }
+            ]
           }
         },
         "strategy": {}

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.json
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.json
@@ -81,7 +81,7 @@
                           ]
                         },
                         {
-                          "key": "beta.kubernetes.io/os",
+                          "key": "kubernetes.io/os",
                           "operator": "In",
                           "values": [
                             "ubuntu 14.04"

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.json
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.json
@@ -106,12 +106,9 @@
                 "topologyKey": "zone",
                 "whenUnsatisfiable": "ScheduleAnyway",
                 "labelSelector": {
-                  "matchExpressions": [
-                    {
-                      "key": "zone",
-                      "operator": "Exists"
-                    }
-                  ]
+                  "matchLabels": {
+                    "io.kompose.service": "redis"
+                  }
                 }
               },
               {
@@ -119,12 +116,9 @@
                 "topologyKey": "ssd",
                 "whenUnsatisfiable": "ScheduleAnyway",
                 "labelSelector": {
-                  "matchExpressions": [
-                    {
-                      "key": "ssd",
-                      "operator": "Exists"
-                    }
-                  ]
+                  "matchLabels": {
+                    "io.kompose.service": "redis"
+                  }
                 }
               }
             ]

--- a/script/test/fixtures/deploy/placement/output-placement-os.json
+++ b/script/test/fixtures/deploy/placement/output-placement-os.json
@@ -101,7 +101,7 @@
                           ]
                         },
                         {
-                          "key": "beta.kubernetes.io/os",
+                          "key": "kubernetes.io/os",
                           "operator": "In",
                           "values": [
                             "ubuntu 14.04"

--- a/script/test/fixtures/deploy/placement/output-placement-os.json
+++ b/script/test/fixtures/deploy/placement/output-placement-os.json
@@ -96,48 +96,58 @@
                         {
                           "key": "kubernetes.io/hostname",
                           "operator": "In",
-                          "values": ["machine"]
+                          "values": [
+                            "machine"
+                          ]
                         },
                         {
                           "key": "beta.kubernetes.io/os",
                           "operator": "In",
-                          "values": ["ubuntu 14.04"]
+                          "values": [
+                            "ubuntu 14.04"
+                          ]
                         },
                         {
                           "key": "foo",
                           "operator": "NotIn",
-                          "values": ["bar"]
+                          "values": [
+                            "bar"
+                          ]
                         }
                       ]
                     }
                   ]
-                },
-                "preferredDuringSchedulingIgnoredDuringExecution": [
-                  {
-                    "weight": 2,
-                    "preference": {
-                      "matchExpressions": [
-                        {
-                          "key": "zone",
-                          "operator": "Exists"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "weight": 1,
-                    "preference": {
-                      "matchExpressions": [
-                        {
-                          "key": "ssd",
-                          "operator": "Exists"
-                        }
-                      ]
-                    }
-                  }
-                ]
+                }
               }
-            }
+            },
+            "topologySpreadConstraints": [
+              {
+                "maxSkew": 2,
+                "topologyKey": "zone",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchExpressions": [
+                    {
+                      "key": "zone",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              },
+              {
+                "maxSkew": 1,
+                "topologyKey": "ssd",
+                "whenUnsatisfiable": "ScheduleAnyway",
+                "labelSelector": {
+                  "matchExpressions": [
+                    {
+                      "key": "ssd",
+                      "operator": "Exists"
+                    }
+                  ]
+                }
+              }
+            ]
           }
         }
       },

--- a/script/test/fixtures/deploy/placement/output-placement-os.json
+++ b/script/test/fixtures/deploy/placement/output-placement-os.json
@@ -126,12 +126,9 @@
                 "topologyKey": "zone",
                 "whenUnsatisfiable": "ScheduleAnyway",
                 "labelSelector": {
-                  "matchExpressions": [
-                    {
-                      "key": "zone",
-                      "operator": "Exists"
-                    }
-                  ]
+                  "matchLabels": {
+                    "io.kompose.service": "redis"
+                  }
                 }
               },
               {
@@ -139,12 +136,9 @@
                 "topologyKey": "ssd",
                 "whenUnsatisfiable": "ScheduleAnyway",
                 "labelSelector": {
-                  "matchExpressions": [
-                    {
-                      "key": "ssd",
-                      "operator": "Exists"
-                    }
-                  ]
+                  "matchLabels": {
+                    "io.kompose.service": "redis"
+                  }
                 }
               }
             ]

--- a/script/test/fixtures/deploy/placement/output-placement-os.json
+++ b/script/test/fixtures/deploy/placement/output-placement-os.json
@@ -111,7 +111,31 @@
                       ]
                     }
                   ]
-                }
+                },
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                  {
+                    "weight": 2,
+                    "preference": {
+                      "matchExpressions": [
+                        {
+                          "key": "zone",
+                          "operator": "Exists"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "weight": 1,
+                    "preference": {
+                      "matchExpressions": [
+                        {
+                          "key": "ssd",
+                          "operator": "Exists"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
           }

--- a/script/test/fixtures/unused/v3/output-deploy-k8s.json
+++ b/script/test/fixtures/unused/v3/output-deploy-k8s.json
@@ -89,7 +89,7 @@
                           "values": ["machine"]
                         },
                         {
-                          "key": "beta.kubernetes.io/os",
+                          "key": "kubernetes.io/oss",
                           "operator": "In",
                           "values": ["ubuntu 14.04"]
                         },

--- a/script/test/fixtures/unused/v3/output-deploy-os.json
+++ b/script/test/fixtures/unused/v3/output-deploy-os.json
@@ -104,7 +104,7 @@
                           "values": ["machine"]
                         },
                         {
-                          "key": "beta.kubernetes.io/os",
+                          "key": "kubernetes.io/os",
                           "operator": "In",
                           "values": ["ubuntu 14.04"]
                         },


### PR DESCRIPTION
https://docs.docker.com/engine/reference/commandline/service_create/#specify-service-placement-preferences---placement-pref

https://docs.docker.com/engine/swarm/services/#placement-preferences

> Placement preferences try to place tasks on appropriate nodes in an algorithmic way (currently, only spread evenly).
> Placement preferences are not strictly enforced. If no node has the label you specify in your preference, the service is deployed as though the preference were not set.

So, I think we can use affinity to support it.
For exmple:
```yaml
deploy:
  placement:
    preferences:
      - spread: node.labels.ssd
```
can be converted to:
```yaml
affinity:
  nodeAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
      - preference:
          matchExpressions:
            - key: ssd
              operator: Exists
        weight: 1