### PR TITLE
Add cmd tests for emptyvols and emptyDir

### DIFF
--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -579,11 +579,6 @@ cmd="kompose convert --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/
 sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-os-template.json > /tmp/output-os.json
 convert::expect_success_and_warning "$cmd" "/tmp/output-os.json" "Volume mount on the host "\"."\" isn't supported - ignoring path on the host"
 
-# Test that empty-vols works
-cmd="kompose convert -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml --stdout -j --volumes emptyDir"
-sed -e "s;%VERSION%;$version;g" -e "s;%CMD%;$cmd;g"  $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json > /tmp/output-k8s.json
-convert::expect_success_and_warning "$cmd" "/tmp/output-k8s.json" "Volume mount on the host "\"."\" isn't supported - ignoring path on the host"
-
 #Failing test for `--volumes` option
 convert::expect_failure "kompose convert --stdout -j -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml --volumes foobar"
 

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -134,6 +134,22 @@ os_output="$KOMPOSE_ROOT/script/test/fixtures/configmap-volume/output-os.json"
 convert::expect_success_and_warning "$k8s_cmd" "$k8s_output"
 convert::expect_success "$os_cmd" "$os_output"
 
+# Test that emptyDir works
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml convert --with-kompose-annotation=false --stdout -j --volumes emptyDir"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json"
+os_cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml convert --with-kompose-annotation=false --stdout -j --volumes emptyDir"
+os_output="$KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-os-empty-vols-template.json"
+convert::expect_success_and_warning "$k8s_cmd" "$k8s_output"
+convert::expect_success_and_warning "$os_cmd" "$os_output"
+
+# Test that emptyvols works
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml convert --with-kompose-annotation=false --stdout -j --emptyvols"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json"
+os_cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/change-in-volume/docker-compose.yml convert --with-kompose-annotation=false --stdout -j --emptyvols"
+os_output="$KOMPOSE_ROOT/script/test/fixtures/change-in-volume/output-os-empty-vols-template.json"
+convert::expect_success_and_warning "$k8s_cmd" "$k8s_output"
+convert::expect_success_and_warning "$os_cmd" "$os_output"
+
 # test service expose
 k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/expose/compose.yaml convert --stdout -j --with-kompose-annotation=false"
 ocp_cmd="kompose  --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/expose/compose.yaml convert --stdout -j --with-kompose-annotation=false"

--- a/script/test/fixtures/change-in-volume/docker-compose.yml
+++ b/script/test/fixtures/change-in-volume/docker-compose.yml
@@ -6,10 +6,13 @@ services:
     ports:
      - "5000:5000"
     volumes:
-     - .:/code
+     - code_volume:/code
     links:
      - redis
   redis:
     image: redis
     labels:
       kompose.service.type: headless
+
+volumes:
+  code_volume:

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.json
@@ -13,9 +13,7 @@
           "io.kompose.service": "redis"
         },
         "annotations": {
-          "kompose.cmd": "%CMD%",
-          "kompose.service.type": "headless",
-          "kompose.version": "%VERSION%"
+          "kompose.service.type": "headless"
         }
       },
       "spec": {
@@ -43,10 +41,6 @@
         "creationTimestamp": null,
         "labels": {
           "io.kompose.service": "web"
-        },
-        "annotations": {
-          "kompose.cmd": "%CMD%",
-          "kompose.version": "%VERSION%"
         }
       },
       "spec": {
@@ -66,19 +60,17 @@
       }
     },
     {
-      "apiVersion": "apps/v1",
       "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
-        "annotations": {
-          "kompose.cmd": "%CMD%",
-          "kompose.service.type": "headless",
-          "kompose.version": "%VERSION%"
-        },
+        "name": "redis",
         "creationTimestamp": null,
         "labels": {
           "io.kompose.service": "redis"
         },
-        "name": "redis"
+        "annotations": {
+          "kompose.service.type": "headless"
+        }
       },
       "spec": {
         "replicas": 1,
@@ -87,49 +79,40 @@
             "io.kompose.service": "redis"
           }
         },
-        "strategy": {},
         "template": {
           "metadata": {
-            "annotations": {
-              "kompose.cmd": "%CMD%",
-              "kompose.service.type": "headless",
-              "kompose.version": "%VERSION%"
-            },
             "creationTimestamp": null,
             "labels": {
               "io.kompose.service": "redis"
+            },
+            "annotations": {
+              "kompose.service.type": "headless"
             }
           },
           "spec": {
             "containers": [
               {
-                "image": "redis",
-                "imagePullPolicy": "",
                 "name": "redis",
+                "image": "redis",
                 "resources": {}
               }
             ],
-            "restartPolicy": "Always",
-            "serviceAccountName": "",
-            "volumes": null
+            "restartPolicy": "Always"
           }
-        }
+        },
+        "strategy": {}
       },
       "status": {}
     },
     {
-      "apiVersion": "apps/v1",
       "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
-        "annotations": {
-          "kompose.cmd": "%CMD%",
-          "kompose.version": "%VERSION%"
-        },
+        "name": "web",
         "creationTimestamp": null,
         "labels": {
           "io.kompose.service": "web"
-        },
-        "name": "web"
+        }
       },
       "spec": {
         "replicas": 1,
@@ -138,30 +121,28 @@
             "io.kompose.service": "web"
           }
         },
-        "strategy": {
-          "type": "Recreate"
-        },
         "template": {
           "metadata": {
-            "annotations": {
-              "kompose.cmd": "%CMD%",
-              "kompose.version": "%VERSION%"
-            },
             "creationTimestamp": null,
             "labels": {
               "io.kompose.service": "web"
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "code-volume",
+                "emptyDir": {}
+              }
+            ],
             "containers": [
               {
+                "name": "web",
+                "image": "flask_web",
                 "args": [
                   "python",
                   "app.py"
                 ],
-                "image": "flask_web",
-                "imagePullPolicy": "",
-                "name": "web",
                 "ports": [
                   {
                     "containerPort": 5000
@@ -170,21 +151,17 @@
                 "resources": {},
                 "volumeMounts": [
                   {
-                    "mountPath": "/code",
-                    "name": "web-empty0"
+                    "name": "code-volume",
+                    "mountPath": "/code"
                   }
                 ]
               }
             ],
-            "restartPolicy": "Always",
-            "serviceAccountName": "",
-            "volumes": [
-              {
-                "emptyDir": {},
-                "name": "web-empty0"
-              }
-            ]
+            "restartPolicy": "Always"
           }
+        },
+        "strategy": {
+          "type": "Recreate"
         }
       },
       "status": {}

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.json
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.json
@@ -1,0 +1,286 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.service.type": "headless"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "headless",
+            "port": 55555,
+            "targetPort": 0
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "redis"
+        },
+        "clusterIP": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "5000",
+            "port": 5000,
+            "targetPort": 5000
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "web"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        },
+        "annotations": {
+          "kompose.service.type": "headless"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "redis"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "redis:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "redis"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "redis"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "redis",
+                "image": " ",
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "latestVersion": 0,
+        "observedGeneration": 0,
+        "replicas": 0,
+        "updatedReplicas": 0,
+        "availableReplicas": 0,
+        "unavailableReplicas": 0
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "redis",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "redis"
+        }
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "name": "",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "redis"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": ""
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "web"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "web:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "web"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "web"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "code-volume",
+                "emptyDir": {}
+              }
+            ],
+            "containers": [
+              {
+                "name": "web",
+                "image": " ",
+                "args": [
+                  "python",
+                  "app.py"
+                ],
+                "ports": [
+                  {
+                    "containerPort": 5000
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "code-volume",
+                    "mountPath": "/code"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "latestVersion": 0,
+        "observedGeneration": 0,
+        "replicas": 0,
+        "updatedReplicas": 0,
+        "availableReplicas": 0,
+        "unavailableReplicas": 0
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "web",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "web"
+        }
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "name": "",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "flask_web"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": ""
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The new cmd tests didn't had tests for these. 
This also verifies that the `kompose convert .... --volumes emptyDir` and `kompose convert .... --emptyvols` are functionally equivalent.