### PR TITLE
Add initial support for statefulset controller.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -94,7 +94,7 @@ INFO OpenShift file "foo-buildconfig.yaml" created
 
 ## Alternative Conversions
 
-The default `kompose` transformation will generate Kubernetes [Deployments](http://kubernetes.io/docs/user-guide/deployments/) and [Services](http://kubernetes.io/docs/user-guide/services/), in yaml format. You have alternative option to generate json with `-j`. Also, you can alternatively generate [Replication Controllers](http://kubernetes.io/docs/user-guide/replication-controller/) objects, [Daemon Sets](http://kubernetes.io/docs/admin/daemons/), or [Helm](https://github.com/helm/helm) charts.
+The default `kompose` transformation will generate Kubernetes [Deployments](http://kubernetes.io/docs/user-guide/deployments/) and [Services](http://kubernetes.io/docs/user-guide/services/), in yaml format. You have alternative option to generate json with `-j`. Also, you can alternatively generate [Replication Controllers](http://kubernetes.io/docs/user-guide/replication-controller/) objects, [Daemon Sets](http://kubernetes.io/docs/admin/daemons/), [Statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) or [Helm](https://github.com/helm/helm) charts.
 
 ```sh
 $ kompose convert -j
@@ -124,6 +124,17 @@ INFO Kubernetes file "web-daemonset.yaml" created
 ```
 
 The `*-daemonset.yaml` files contain the Daemon Set objects
+
+```sh
+$ kompose convert --controller statefulset
+INFO Kubernetes file "db-service.yaml" created    
+INFO Kubernetes file "wordpress-service.yaml" created 
+INFO Kubernetes file "db-statefulset.yaml" created 
+INFO Kubernetes file "wordpress-statefulset.yaml" created 
+```
+
+The `*statefulset-.yaml` files contain the Statefulset objects.
+
 
 If you want to generate a Chart to be used with [Helm](https://github.com/kubernetes/helm) simply do:
 

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -644,6 +644,8 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 				persistentVolumeClaims := make([]api.PersistentVolumeClaim, len(pvc))
 				for i, persistentVolumeClaim := range pvc {
 					persistentVolumeClaims[i] = *persistentVolumeClaim
+					persistentVolumeClaims[i].APIVersion = ""
+					persistentVolumeClaims[i].Kind = ""
 				}
 				objType.Spec.VolumeClaimTemplates = persistentVolumeClaims
 			}

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -496,7 +496,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		volumesMount = append(volumesMount, TmpVolumesMount...)
 	}
 
-	if pvc != nil {
+	if pvc != nil && opt.Controller != StatefulStateController {
 		// Looping on the slice pvc instead of `*objects = append(*objects, pvc...)`
 		// because the type of objects and pvc is different, but when doing append
 		// one element at a time it gets converted to runtime.Object for objects slice
@@ -530,7 +530,9 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		template.Spec.Containers[0].VolumeMounts = append(template.Spec.Containers[0].VolumeMounts, volumesMount...)
 		template.Spec.Containers[0].Stdin = service.Stdin
 		template.Spec.Containers[0].TTY = service.Tty
-		template.Spec.Volumes = append(template.Spec.Volumes, volumes...)
+		if opt.Controller != StatefulStateController {
+			template.Spec.Volumes = append(template.Spec.Volumes, volumes...)
+		}
 		template.Spec.Affinity = ConfigAffinity(service)
 		// Configure the HealthCheck
 		template.Spec.Containers[0].LivenessProbe = configProbe(service.HealthChecks.Liveness)
@@ -637,6 +639,13 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 				objType.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 			case *deployapi.DeploymentConfig:
 				objType.Spec.Strategy.Type = deployapi.DeploymentStrategyTypeRecreate
+			case *appsv1.StatefulSet:
+				// embed all PVCs inside the StatefulSet object
+				persistentVolumeClaims := make([]api.PersistentVolumeClaim, len(pvc))
+				for i, persistentVolumeClaim := range pvc {
+					persistentVolumeClaims[i] = *persistentVolumeClaim
+				}
+				objType.Spec.VolumeClaimTemplates = persistentVolumeClaims
 			}
 		}
 	}

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -530,7 +530,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 		template.Spec.Containers[0].VolumeMounts = append(template.Spec.Containers[0].VolumeMounts, volumesMount...)
 		template.Spec.Containers[0].Stdin = service.Stdin
 		template.Spec.Containers[0].TTY = service.Tty
-		if opt.Controller != StatefulStateController {
+		if opt.Controller != StatefulStateController || opt.Volumes == "configMap" {
 			template.Spec.Volumes = append(template.Spec.Volumes, volumes...)
 		}
 		template.Spec.Affinity = ConfigAffinity(service)
@@ -641,6 +641,9 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 				objType.Spec.Strategy.Type = deployapi.DeploymentStrategyTypeRecreate
 			case *appsv1.StatefulSet:
 				// embed all PVCs inside the StatefulSet object
+				if opt.Volumes == "configMap" {
+					break
+				}
 				persistentVolumeClaims := make([]api.PersistentVolumeClaim, len(pvc))
 				for i, persistentVolumeClaim := range pvc {
 					persistentVolumeClaims[i] = *persistentVolumeClaim

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1443,6 +1443,9 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 			objects = k.CreateWorkloadAndConfigMapObjects(name, service, opt)
 		}
 
+		if opt.Controller == StatefulStateController {
+			service.ServiceType = "Headless"
+		}
 		k.configKubeServiceAndIngressForService(service, name, &objects)
 
 		err := k.UpdateKubernetesObjects(name, service, opt, &objects)

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -428,6 +428,12 @@ func (k *Kubernetes) InitDS(name string, service kobject.ServiceConfig) *appsv1.
 }
 
 func (k *Kubernetes) InitSS(name string, service kobject.ServiceConfig, replicas int) *appsv1.StatefulSet {
+	var podSpec api.PodSpec
+	if len(service.Configs) > 0 {
+		podSpec = k.InitPodSpecWithConfigMap(name, service.Image, service)
+	} else {
+		podSpec = k.InitPodSpec(name, service.Image, service.ImagePullSecret)
+	}
 	rp := int32(replicas)
 	ds := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -441,7 +447,7 @@ func (k *Kubernetes) InitSS(name string, service kobject.ServiceConfig, replicas
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &rp,
 			Template: api.PodTemplateSpec{
-				Spec: k.InitPodSpec(name, service.Image, service.ImagePullSecret),
+				Spec: podSpec,
 			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: transformer.ConfigLabels(name),

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -179,3 +179,11 @@ k8s_output="$KOMPOSE_ROOT/script/test/fixtures/healthcheck/output-healthcheck-k8
 os_output="$KOMPOSE_ROOT/script/test/fixtures/healthcheck/output-healthcheck-os.json"
 convert::expect_success "$k8s_cmd" "$k8s_output"
 convert::expect_success "$os_cmd" "$os_output"
+
+# test statefulset
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/statefulset/docker-compose.yaml convert --stdout -j --with-kompose-annotation=false --controller statefulset"
+ocp_cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/statefulset/docker-compose.yaml convert --stdout -j --with-kompose-annotation=false --controller statefulset"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/statefulset/output-k8s.json"
+ocp_output="$KOMPOSE_ROOT/script/test/fixtures/statefulset/output-os.json"
+convert::expect_success "$k8s_cmd" "$k8s_output"
+convert::expect_success "$ocp_cmd" "$ocp_output"

--- a/script/test/fixtures/statefulset/docker-compose.yaml
+++ b/script/test/fixtures/statefulset/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "3"
+    
+services:
+  db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    ports:
+      - "3306:3306"
+    
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:latest
+    volumes:
+      - wordpress_data:/var/www/html
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+volumes:
+  db_data: {}
+  wordpress_data: {}

--- a/script/test/fixtures/statefulset/output-k8s.json
+++ b/script/test/fixtures/statefulset/output-k8s.json
@@ -1,0 +1,249 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "3306",
+            "port": 3306,
+            "targetPort": 3306
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "db"
+        },
+        "clusterIP": "None",
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "8000",
+            "port": 8000,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "wordpress"
+        },
+        "clusterIP": "None",
+        "type": "ClusterIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "StatefulSet",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "io.kompose.service": "db"
+          }
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "db"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "db",
+                "image": "mysql:5.7",
+                "ports": [
+                  {
+                    "containerPort": 3306
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "somewordpress"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "wordpress"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "db-data",
+                    "mountPath": "/var/lib/mysql"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "metadata": {
+              "name": "db-data",
+              "creationTimestamp": null,
+              "labels": {
+                "io.kompose.service": "db-data"
+              }
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "100Mi"
+                }
+              }
+            },
+            "status": {}
+          }
+        ],
+        "serviceName": "db",
+        "updateStrategy": {}
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "StatefulSet",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "io.kompose.service": "wordpress"
+          }
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "wordpress"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "wordpress",
+                "image": "wordpress:latest",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "WORDPRESS_DB_HOST",
+                    "value": "db:3306"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_NAME",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_PASSWORD",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_USER",
+                    "value": "wordpress"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "wordpress-data",
+                    "mountPath": "/var/www/html"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "metadata": {
+              "name": "wordpress-data",
+              "creationTimestamp": null,
+              "labels": {
+                "io.kompose.service": "wordpress-data"
+              }
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "100Mi"
+                }
+              }
+            },
+            "status": {}
+          }
+        ],
+        "serviceName": "wordpress",
+        "updateStrategy": {}
+      },
+      "status": {
+        "replicas": 0
+      }
+    }
+  ]
+}

--- a/script/test/fixtures/statefulset/output-os.json
+++ b/script/test/fixtures/statefulset/output-os.json
@@ -1,0 +1,503 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "3306",
+            "port": 3306,
+            "targetPort": 3306
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "db"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "8000",
+            "port": 8000,
+            "targetPort": 80
+          }
+        ],
+        "selector": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "StatefulSet",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "io.kompose.service": "db"
+          }
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "db"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "db",
+                "image": "mysql:5.7",
+                "ports": [
+                  {
+                    "containerPort": 3306
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "somewordpress"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "wordpress"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "db-data",
+                    "mountPath": "/var/lib/mysql"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "metadata": {
+              "name": "db-data",
+              "creationTimestamp": null,
+              "labels": {
+                "io.kompose.service": "db-data"
+              }
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "100Mi"
+                }
+              }
+            },
+            "status": {}
+          }
+        ],
+        "serviceName": "db",
+        "updateStrategy": {}
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "db"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "db:5.7"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "db"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "db"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "db",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 3306
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "somewordpress"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "wordpress"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "db-data",
+                    "mountPath": "/var/lib/mysql"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "latestVersion": 0,
+        "observedGeneration": 0,
+        "replicas": 0,
+        "updatedReplicas": 0,
+        "availableReplicas": 0,
+        "unavailableReplicas": 0
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "db",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "db"
+        }
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "name": "",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "mysql:5.7"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": ""
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    },
+    {
+      "kind": "StatefulSet",
+      "apiVersion": "apps/v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "io.kompose.service": "wordpress"
+          }
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "wordpress"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "wordpress",
+                "image": "wordpress:latest",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "WORDPRESS_DB_HOST",
+                    "value": "db:3306"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_NAME",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_PASSWORD",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_USER",
+                    "value": "wordpress"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "wordpress-data",
+                    "mountPath": "/var/www/html"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "volumeClaimTemplates": [
+          {
+            "metadata": {
+              "name": "wordpress-data",
+              "creationTimestamp": null,
+              "labels": {
+                "io.kompose.service": "wordpress-data"
+              }
+            },
+            "spec": {
+              "accessModes": [
+                "ReadWriteOnce"
+              ],
+              "resources": {
+                "requests": {
+                  "storage": "100Mi"
+                }
+              }
+            },
+            "status": {}
+          }
+        ],
+        "serviceName": "wordpress",
+        "updateStrategy": {}
+      },
+      "status": {
+        "replicas": 0
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "wordpress"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "name": "wordpress:latest"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "io.kompose.service": "wordpress"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "io.kompose.service": "wordpress"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "wordpress",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": 80
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "WORDPRESS_DB_HOST",
+                    "value": "db:3306"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_NAME",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_PASSWORD",
+                    "value": "wordpress"
+                  },
+                  {
+                    "name": "WORDPRESS_DB_USER",
+                    "value": "wordpress"
+                  }
+                ],
+                "resources": {},
+                "volumeMounts": [
+                  {
+                    "name": "wordpress-data",
+                    "mountPath": "/var/www/html"
+                  }
+                ]
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {
+        "latestVersion": 0,
+        "observedGeneration": 0,
+        "replicas": 0,
+        "updatedReplicas": 0,
+        "availableReplicas": 0,
+        "unavailableReplicas": 0
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "wordpress",
+        "creationTimestamp": null,
+        "labels": {
+          "io.kompose.service": "wordpress"
+        }
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "name": "",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "wordpress:latest"
+            },
+            "generation": null,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": ""
+            }
+          }
+        ]
+      },
+      "status": {
+        "dockerImageRepository": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds option to use `StatefulSet` as a controller.
Usage: 
```bash
kompose convert -f ./path/to/docker-compose.yml  --controller statefulset
```

Example 

```yaml
# docker-compose.yaml
version: '2'
services:
  web:
    image: python
    volumes:
     - app:/app
    ports:
     - "8080:8080"

volumes:
  app:
```

Kompose output 
```yaml
apiVersion: v1
items:
  - apiVersion: v1
    kind: Service
    metadata:
      annotations:
        kompose.cmd: ./kompose convert -f ./compose-test.yaml --stdout --controller statefulset
        kompose.version: 1.24.0 (4a2a0458)
      creationTimestamp: null
      labels:
        io.kompose.service: web
      name: web
    spec:
      clusterIP: None
      ports:
        - name: "8080"
          port: 8080
          targetPort: 8080
      selector:
        io.kompose.service: web
      type: ClusterIP
    status:
      loadBalancer: {}
  - apiVersion: apps/v1
    kind: StatefulSet
    metadata:
      annotations:
        kompose.cmd: ./kompose convert -f ./compose-test.yaml --stdout --controller statefulset
        kompose.version: 1.24.0 (4a2a0458)
      creationTimestamp: null
      labels:
        io.kompose.service: web
      name: web
    spec:
      replicas: 1
      selector:
        matchLabels:
          io.kompose.service: web
      serviceName: web
      template:
        metadata:
          creationTimestamp: null
          labels:
            io.kompose.service: web
        spec:
          containers:
            - image: python
              name: web
              ports:
                - containerPort: 8080
              resources: {}
              volumeMounts:
                - mountPath: /app
                  name: app
          restartPolicy: Always
      updateStrategy: {}
      volumeClaimTemplates:
        - metadata:
            creationTimestamp: null
            labels:
              io.kompose.service: app
            name: app
          spec:
            accessModes:
              - ReadWriteOnce
            resources:
              requests:
                storage: 100Mi
          status: {}
    status:
      replicas: 0
kind: List
metadata: {}

```

TODOs:

- [ ] Get the statefulset option right
- [x] Add cmd tests
- [x] Add unit tests 
- [x] Add headless service for netwoking.

