### PR TITLE
Update README for docs website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,5 @@ bundle exec jekyll serve .
 ```
 
 And visiting `localhost:4000` on your browser.
+
+This website is synced to the `gh-pages` branch.


### PR DESCRIPTION
Updates the README to say that the site is synced to `gh-pages`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>