### PR TITLE
Remove [file] from convert helptext

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -66,7 +66,7 @@ var (
 )
 
 var convertCmd = &cobra.Command{
-	Use:   "convert [file]",
+	Use:   "convert",
 	Short: "Convert a Docker Compose file",
 	PreRun: func(cmd *cobra.Command, args []string) {
 


### PR DESCRIPTION
Since `kompose convert` doesn't accept a `[file]` argument (instead it accepts the the -f/--file flag), I removed that from the help text.