### PR TITLE
fix(v3): Added network name normalisation in v3 parsing

### DIFF
--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -439,7 +439,9 @@ func dockerComposeToKomposeMapping(composeObject *types.Config) (kobject.Kompose
 			serviceConfig.StopGracePeriod = composeServiceConfig.StopGracePeriod.String()
 		}
 
-		parseV3Network(&composeServiceConfig, &serviceConfig, composeObject)
+		if err := parseV3Network(&composeServiceConfig, &serviceConfig, composeObject); err != nil {
+			return kobject.KomposeObject{}, err
+		}
 
 		if err := parseV3Resources(&composeServiceConfig, &serviceConfig); err != nil {
 			return kobject.KomposeObject{}, err
@@ -556,24 +558,37 @@ func resolveV3Context(inFile string, context string) string {
 	return current
 }
 
-func parseV3Network(composeServiceConfig *types.ServiceConfig, serviceConfig *kobject.ServiceConfig, composeObject *types.Config) {
+func parseV3Network(composeServiceConfig *types.ServiceConfig, serviceConfig *kobject.ServiceConfig, composeObject *types.Config) error {
 	if len(composeServiceConfig.Networks) == 0 {
 		if defaultNetwork, ok := composeObject.Networks["default"]; ok {
-			serviceConfig.Network = append(serviceConfig.Network, defaultNetwork.Name)
+			normalizedNetworkName, err := normalizeNetworkNames(defaultNetwork.Name)
+			if err != nil {
+				return errors.Wrap(err, "Unable to normalize network name")
+			}
+			serviceConfig.Network = append(serviceConfig.Network, normalizedNetworkName)
 		}
 	} else {
 		var alias = ""
 		for key := range composeServiceConfig.Networks {
 			alias = key
 			netName := composeObject.Networks[alias].Name
+
 			// if Network Name Field is empty in the docker-compose definition
 			// we will use the alias name defined in service config file
 			if netName == "" {
 				netName = alias
 			}
-			serviceConfig.Network = append(serviceConfig.Network, netName)
+
+			normalizedNetworkName, err := normalizeNetworkNames(netName)
+			if err != nil {
+				return errors.Wrap(err, "Unable to normalize network name")
+			}
+
+			serviceConfig.Network = append(serviceConfig.Network, normalizedNetworkName)
 		}
 	}
+
+	return nil
 }
 
 func parseV3Resources(composeServiceConfig *types.ServiceConfig, serviceConfig *kobject.ServiceConfig) error {

--- a/script/test/fixtures/v3.0/docker-compose.yaml
+++ b/script/test/fixtures/v3.0/docker-compose.yaml
@@ -17,7 +17,9 @@ services:
     networks:
       app: {}
       web: {}
+      normalized_network: {}
 networks:
+  normalized_network:
   app:
     external:
       name: app-network

--- a/script/test/fixtures/v3.0/output-k8s.json
+++ b/script/test/fixtures/v3.0/output-k8s.json
@@ -55,6 +55,7 @@
             "creationTimestamp": null,
             "labels": {
               "io.kompose.network/app-network": "true",
+              "io.kompose.network/normalized-network": "true",
               "io.kompose.network/web-network": "true",
               "io.kompose.service": "foo"
             }
@@ -99,6 +100,34 @@
                 "podSelector": {
                   "matchLabels": {
                     "io.kompose.network/app-network": "true"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "kind": "NetworkPolicy",
+      "apiVersion": "networking.k8s.io/v1",
+      "metadata": {
+        "name": "normalized-network",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "podSelector": {
+          "matchLabels": {
+            "io.kompose.network/normalized-network": "true"
+          }
+        },
+        "ingress": [
+          {
+            "from": [
+              {
+                "podSelector": {
+                  "matchLabels": {
+                    "io.kompose.network/normalized-network": "true"
                   }
                 }
               }

--- a/script/test/fixtures/v3.0/output-os.json
+++ b/script/test/fixtures/v3.0/output-os.json
@@ -75,6 +75,7 @@
             "creationTimestamp": null,
             "labels": {
               "io.kompose.network/app-network": "true",
+              "io.kompose.network/normalized-network": "true",
               "io.kompose.network/web-network": "true",
               "io.kompose.service": "foo"
             }


### PR DESCRIPTION
Fixes #1487 
Current parsing of network names in v3 doesn't provide network name normalization that causes incorrect label names and incorrect networkpolicy resource name