### PR TITLE
fix: change the port ID definition in kubernetes.go file

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -18,6 +18,7 @@ package kobject
 
 import (
 	"path/filepath"
+	"strconv"
 	"time"
 
 	dockerCliTypes "github.com/docker/cli/cli/compose/types"
@@ -196,7 +197,7 @@ type Ports struct {
 
 // ID returns an unique id for this port settings, to avoid conflict
 func (port *Ports) ID() string {
-	return string(port.ContainerPort) + port.Protocol
+	return strconv.Itoa(int(port.ContainerPort)) + port.Protocol
 }
 
 // Volumes holds the volume struct of container

--- a/pkg/loader/compose/v1v2.go
+++ b/pkg/loader/compose/v1v2.go
@@ -90,7 +90,6 @@ func parseV1V2(files []string) (kobject.KomposeObject, error) {
 func loadPorts(composePorts []string, expose []string) ([]kobject.Ports, error) {
 	kp := []kobject.Ports{}
 	exist := map[string]bool{}
-
 	for _, cp := range composePorts {
 		var hostIP string
 

--- a/pkg/loader/compose/v3.go
+++ b/pkg/loader/compose/v3.go
@@ -222,7 +222,6 @@ func loadV3Volumes(volumes []types.ServiceVolumeConfig) []string {
 // expose ports will be treated as TCP ports
 func loadV3Ports(ports []types.ServicePortConfig, expose []string) []kobject.Ports {
 	komposePorts := []kobject.Ports{}
-
 	exist := map[string]bool{}
 
 	for _, port := range ports {
@@ -235,7 +234,6 @@ func loadV3Ports(ports []types.ServicePortConfig, expose []string) []kobject.Por
 			HostIP:        "",
 			Protocol:      strings.ToUpper(port.Protocol),
 		})
-
 		exist[cast.ToString(port.Target)+port.Protocol] = true
 	}
 

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -513,7 +513,6 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 
 	// Configure the container ports.
 	ports := ConfigPorts(service)
-
 	// Configure capabilities
 	capabilities := ConfigCapabilities(service)
 

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1436,7 +1436,6 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 						objects = append(objects, c)
 					}
 				}
-
 				podSpec.Append(
 					SetPorts(service),
 					ImagePullPolicy(name, service),
@@ -1492,17 +1491,14 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 		} else {
 			objects = k.CreateWorkloadAndConfigMapObjects(name, service, opt)
 		}
-
 		if opt.Controller == StatefulStateController {
 			service.ServiceType = "Headless"
 		}
 		k.configKubeServiceAndIngressForService(service, name, &objects)
-
 		err := k.UpdateKubernetesObjects(name, service, opt, &objects)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error transforming Kubernetes objects")
 		}
-
 		if err := k.configNetworkPolicyForService(service, name, &objects); err != nil {
 			return nil, err
 		}
@@ -1513,7 +1509,6 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 	k.SortServicesFirst(&allobjects)
 	k.RemoveDupObjects(&allobjects)
 	// k.FixWorkloadVersion(&allobjects)
-
 	return allobjects, nil
 }
 

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -44,7 +44,7 @@ func newServiceConfig() kobject.ServiceConfig {
 		ContainerName:   "name",
 		Image:           "image",
 		Environment:     []kobject.EnvVar{kobject.EnvVar{Name: "env", Value: "value"}},
-		Port:            []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456}, kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: string(api.ProtocolUDP)}},
+		Port:            []kobject.Ports{kobject.Ports{HostPort: 123, ContainerPort: 456}, kobject.Ports{HostPort: 123, ContainerPort: 456, Protocol: string(api.ProtocolUDP)}, kobject.Ports{HostPort: 55564, ContainerPort: 55564}, kobject.Ports{HostPort: 55563, ContainerPort: 55563}},
 		Command:         []string{"cmd"},
 		WorkingDir:      "dir",
 		Args:            []string{"arg1", "arg2"},
@@ -119,6 +119,7 @@ func equalPorts(kobjectPorts []kobject.Ports, k8sPorts []api.ContainerPort) bool
 		return false
 	}
 	for _, port := range kobjectPorts {
+		fmt.Println(port)
 		found := false
 		for _, k8sPort := range k8sPorts {
 			// FIXME: HostPort should be copied to container port

--- a/pkg/transformer/kubernetes/podspec.go
+++ b/pkg/transformer/kubernetes/podspec.go
@@ -210,7 +210,6 @@ func SetPorts(service kobject.ServiceConfig) PodSpecOption {
 	return func(podSpec *PodSpec) {
 		// Configure the container ports.
 		ports := ConfigPorts(service)
-
 		for i := range podSpec.Containers {
 			if GetContainerName(service) == podSpec.Containers[i].Name {
 				podSpec.Containers[i].Ports = ports


### PR DESCRIPTION
# Problem
Fix this [issue](https://github.com/kubernetes/kompose/issues/1514). The problem was mainly, in the ID of each port.
In the previous implementation, the ID was composed of the ASCII code of the port number and its protocol. However, such implementation led to some inconveniences for the large port numbers. In fact, If you try this command `fmt.Println(string(55546) == string(55547))` it will print `true`, which is not the desired behavior and it's the main cause behind the issue.
# Solution
To overcome this issue, I just replaced the `string()` function with `strconv.Itoa()`. I added large close numbers in the tests suite, to ensure that we get the desired behavior.