### PR TITLE
remove sync docs from ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,3 @@ jobs:
         env:
           # As per https://github.com/mattn/goveralls#github-actions
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./script/sync-docs.sh
-        if: ${{ github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
remove sync docs from ci

don't need sync docs since we are building from `/docs` directory
instead of `gh-pages`.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
