### PR TITLE
fix(tests): Update match output function

### DIFF
--- a/script/test/cmd/lib.sh
+++ b/script/test/cmd/lib.sh
@@ -100,7 +100,7 @@ function convert::match_output() {
     convert::run_cmd $cmd
     exit_status=$?
     if [ $exit_status -ne 0 ]; then FAIL_MSGS=$FAIL_MSGS"exit status: $exit_status\n"; return $exit_status; fi
-    match=$(diff <(yq -P 'sort_keys(....)' $expected_output) <(yq -P 'sort_keys(....)' $TEMP_STDOUT))
+    match=$(diff <(yq ea '[.] | sort_by(.metadata.name) | .[] | splitDoc' $expected_output) <(yq ea '[.] | sort_by(.metadata.name) | .[] | splitDoc' $TEMP_STDOUT))
     echo "$match" > /tmp/diff
     if [ "$match" == "" ]; then SUCCESS_MSGS=$SUCCESS_MSGS"converted output matches\n"; return 0;
     else FAIL_MSGS=$FAIL_MSGS"converted output does not match\n"; cat /tmp/diff; rm /tmp/diff; return 1; 


### PR DESCRIPTION
# Description
This PR aims to update the match output function, used in the e2e test because currently, it's not working in the predicted manner.

In the previous implementation, we were using the `sort_keys` operator of `yq` but using the recursive method, which caused this error: `Error: bad expression, please check expression syntax` in some tests ( But it was not reflected in the pipeline because status code is 0 ). 
As a solution, we can use `sort_keys(.metadata.name)`, since we are working with k8s or os manifests which always have the `metadata.name` keyword.