### PR TITLE
corrected broken diagram link in site

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ redirect_from:
 
 `kompose` has 3 stages: Loader, Transformer and Outputter. Each Stage should have well defined interface so it is easy to write new Loader, Transformer or Outputters and plug it in. Currently only Loader and Transformer interfaces are defined.
 
-![Design Diagram](/docs/images/design_diagram.png)
+![Design Diagram](https://github.com/kubernetes/kompose/blob/master/docs/images/design_diagram.png)
 
 ## Loader
 

--- a/docs/maven-example.md
+++ b/docs/maven-example.md
@@ -95,4 +95,4 @@ Created the new window in existing browser session.
 
 It will open your application endpoint in default browser.
 
-![Output-Diagram](/docs/images/kompose-maven-output-diagram.png)
+![Output-Diagram](https://github.com/kubernetes/kompose/blob/master/docs/images/kompose-maven-output-diagram.png)


### PR DESCRIPTION
Fixes: #1556 
Replaced diagrams relative link with absolute link to work properly on site 
file changed:
architecture.md
maven-example.md
