### PR TITLE
change master to main in scripts and docs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 env:
   # Avoid noisy outputs like "tput: No value for $TERM and no -T specified"
   TERM: dumb

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,3 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: "Run go vet"
         run: "go vet ./pkg/..."
-      - name: "Run staticcheck"
-        uses: dominikh/staticcheck-action@v1
-        with:
-          cache-key: "${{ matrix.go }}"
-          install-go: false
-          version: "latest"
-          working-directory: "pkg"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Kompose CI
 on:
   push:
     branches:
-      - master
+      - main 
   pull_request:
 env:
   # Avoid noisy outputs like "tput: No value for $TERM and no -T specified"

--- a/Makefile
+++ b/Makefile
@@ -91,15 +91,11 @@ gen-cmd:
 
 # run all validation tests
 .PHONY: validate
-validate: gofmt vet staticcheck
+validate: gofmt vet
 
 .PHONY: vet
 vet:
 	go vet ./pkg/...
-
-.PHONY: staticcheck
-staticcheck:
-	staticcheck ./pkg/...
 
 .PHONY: gofmt
 gofmt:
@@ -114,7 +110,6 @@ test: bin test-dep  validate test-unit-cover install test-cmd
 test-dep:
 	go install github.com/mattn/goveralls@latest
 	go install github.com/modocache/gover@latest
-	go install honnef.co/go/tools/cmd/staticcheck@latest
 	go install github.com/mitchellh/gox@latest
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Use Case
 
-Convert [`docker-compose.yaml`](https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml) into Kubernetes deployments and services with one simple command:
+Convert [`docker-compose.yaml`](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml) into Kubernetes deployments and services with one simple command:
 
 ```sh
 $ kompose convert -f docker-compose.yaml
@@ -121,7 +121,7 @@ $ make test
 
 ## Documentation
 
-Documentation can be found at our [kompose.io](http://kompose.io) website or our [docs](https://github.com/kubernetes/kompose/tree/master/docs) folder.
+Documentation can be found at our [kompose.io](http://kompose.io) website or our [docs](https://github.com/kubernetes/kompose/tree/main/docs) folder.
 
 Here is a list of all available docs:
 
@@ -148,7 +148,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [Build Status Widget]: https://github.com/kubernetes/kompose/workflows/Kompose%20CI/badge.svg
 [GoDoc]: https://godoc.org/github.com/kubernetes/kompose
 [GoDoc Widget]: https://godoc.org/github.com/kubernetes/kompose?status.svg
-[Coverage Status Widget]: https://coveralls.io/repos/github/kubernetes/kompose/badge.svg?branch=master
-[Coverage Status]: https://coveralls.io/github/kubernetes/kompose?branch=master
+[Coverage Status Widget]: https://coveralls.io/repos/github/kubernetes/kompose/badge.svg?branch=main
+[Coverage Status]: https://coveralls.io/github/kubernetes/kompose?branch=main
 [GoReportCard Widget]: https://goreportcard.com/badge/github.com/kubernetes/kompose
 [GoReportCardResult]: https://goreportcard.com/report/github.com/kubernetes/kompose

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,7 +41,7 @@ git checkout -b myfeature
 
 ```console
 git fetch upstream
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 Note: If you have write access to the main repository at github.com/kubernetes/kompose, you should modify your git configuration so that you can't accidentally push to upstream:
@@ -77,7 +77,7 @@ Currently, it is not possible to use a different Kubernetes version from the ver
 
 ### Adding CLI tests
 
-[Kompose CLI tests](https://github.com/kubernetes/kompose/tree/master/script/test/cmd) run `kompose convert` with docker-compose files, and cross-check the k8s and OpenShift artifacts generated with the template files.
+[Kompose CLI tests](https://github.com/kubernetes/kompose/tree/main/script/test/cmd) run `kompose convert` with docker-compose files, and cross-check the k8s and OpenShift artifacts generated with the template files.
 
 To generate CLI tests, please run `make gen-cmd`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,10 +44,10 @@ Starting cluster components...
 Kubectl is now configured to use the cluster
 ```
 
-**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml), or use your own:**
+**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:**
 
 ```sh
-wget https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml
+wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml
 ```
 
 **Convert your Docker Compose file to Kubernetes:**
@@ -134,10 +134,14 @@ Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
 ```
 
+<<<<<<< HEAD
 **Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml), or use your own:**
+=======
+__Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:__
+>>>>>>> fa5394da8 (change master to main in scripts and docs)
 
 ```sh
-wget https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml
+wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml
 ```
 
 **Convert your Docker Compose file to OpenShift:**
@@ -254,10 +258,14 @@ Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
 ```
 
+<<<<<<< HEAD
 **Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml), or use your own:**
+=======
+__Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:__
+>>>>>>> fa5394da8 (change master to main in scripts and docs)
 
 ```sh
-wget https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml
+wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml
 ```
 
 **Convert your Docker Compose file to OpenShift:**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,11 +134,7 @@ Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
 ```
 
-<<<<<<< HEAD
-**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml), or use your own:**
-=======
-__Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:__
->>>>>>> fa5394da8 (change master to main in scripts and docs)
+**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:**
 
 ```sh
 wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml
@@ -258,11 +254,7 @@ Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
 ```
 
-<<<<<<< HEAD
-**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/master/examples/docker-compose.yaml), or use your own:**
-=======
-__Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:__
->>>>>>> fa5394da8 (change master to main in scripts and docs)
+**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml), or use your own:**
 
 ```sh
 wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/docker-compose.yaml

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ Download from [GitHub](https://github.com/kubernetes/kompose/releases/download/v
 
 ## Go
 
-Installing using `go install` pulls from the master branch with the latest development changes.
+Installing using `go install` pulls from the main branch with the latest development changes.
 
 ```sh
 go install github.com/kubernetes/kompose@latest

--- a/docs/maven-example.md
+++ b/docs/maven-example.md
@@ -106,4 +106,4 @@ Created the new window in existing browser session.
 
 It will open your application endpoint in default browser.
 
-![Output-Diagram](https://github.com/kubernetes/kompose/blob/master/docs/images/kompose-maven-output-diagram.png)
+![Output-Diagram](https://github.com/kubernetes/kompose/blob/main/docs/images/kompose-maven-output-diagram.png)

--- a/script/test_in_container/Dockerfile
+++ b/script/test_in_container/Dockerfile
@@ -36,8 +36,6 @@ ENV PATH="$PATH:$GOPATH/bin:$GOROOT/bin" \
 WORKDIR /tmp/go
 RUN curl https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz | tar -xz -C /usr/local
 
-RUN go get honnef.co/go/tools/cmd/staticcheck@latest
-
 WORKDIR $KOMPOSE_SRC
 # This image can be run as any user
 RUN chmod -R ugo+rw $GOPATH


### PR DESCRIPTION
change master to main in scripts and docs

Changes the naming from master to main in the scripts and documentation.

Do not merge unless CI passes!

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
