### PR TITLE
fix: support host port and protocol in functional tests

### DIFF
--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -115,6 +115,8 @@ spec:
           name: web
           ports:
             - containerPort: 5000
+              hostPort: 5000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /code

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -138,6 +138,8 @@ spec:
           name: web
           ports:
             - containerPort: 5000
+              hostPort: 5000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /code

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
@@ -59,6 +59,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
           resources: {}
       restartPolicy: Always
       topologySpreadConstraints:

--- a/script/test/fixtures/deploy/placement/output-placement-os.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-os.yaml
@@ -59,6 +59,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
           resources: {}
       restartPolicy: Always
       topologySpreadConstraints:

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -64,6 +64,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
           resources: {}
       restartPolicy: Always
 status: {}
@@ -118,6 +119,8 @@ spec:
           name: web
           ports:
             - containerPort: 5000
+              hostPort: 5000
+              protocol: TCP
           resources: {}
       restartPolicy: Always
 status: {}

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -64,6 +64,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
           resources: {}
       restartPolicy: Always
   test: false
@@ -139,6 +140,8 @@ spec:
           name: web
           ports:
             - containerPort: 5000
+              hostPort: 5000
+              protocol: TCP
           resources: {}
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
@@ -4,31 +4,6 @@ kind: Service
 metadata:
   annotations:
     kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8081"
-    kompose.service.healthcheck.readiness.interval: 11s
-    kompose.service.healthcheck.readiness.retries: "6"
-    kompose.service.healthcheck.readiness.tcp_port: "9091"
-    kompose.service.healthcheck.readiness.timeout: 2s
-  creationTimestamp: null
-  labels:
-    io.kompose.service: my-group
-  name: mysql
-spec:
-  ports:
-    - name: "3306"
-      port: 3306
-      targetPort: 3306
-  selector:
-    io.kompose.service: my-group
-status:
-  loadBalancer: {}
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    kompose.service.group: my-group
     kompose.service.healthcheck.liveness.tcp_port: "8080"
     kompose.service.healthcheck.readiness.interval: 10s
     kompose.service.healthcheck.readiness.retries: "5"
@@ -43,6 +18,31 @@ spec:
     - name: "27017"
       port: 27017
       targetPort: 27017
+  selector:
+    io.kompose.service: my-group
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.service.group: my-group
+    kompose.service.healthcheck.liveness.tcp_port: "8081"
+    kompose.service.healthcheck.readiness.interval: 11s
+    kompose.service.healthcheck.readiness.retries: "6"
+    kompose.service.healthcheck.readiness.tcp_port: "9091"
+    kompose.service.healthcheck.readiness.timeout: 2s
+  creationTimestamp: null
+  labels:
+    io.kompose.service: my-group
+  name: mysql
+spec:
+  ports:
+    - name: "3306"
+      port: 3306
+      targetPort: 3306
   selector:
     io.kompose.service: my-group
 status:
@@ -103,11 +103,11 @@ kind: Deployment
 metadata:
   annotations:
     kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.tcp_port: "9090"
-    kompose.service.healthcheck.readiness.timeout: 1s
+    kompose.service.healthcheck.liveness.tcp_port: "8081"
+    kompose.service.healthcheck.readiness.interval: 11s
+    kompose.service.healthcheck.readiness.retries: "6"
+    kompose.service.healthcheck.readiness.tcp_port: "9091"
+    kompose.service.healthcheck.readiness.timeout: 2s
   creationTimestamp: null
   labels:
     io.kompose.service: my-group
@@ -122,34 +122,17 @@ spec:
     metadata:
       annotations:
         kompose.service.group: my-group
-        kompose.service.healthcheck.liveness.tcp_port: "8081"
-        kompose.service.healthcheck.readiness.interval: 11s
-        kompose.service.healthcheck.readiness.retries: "6"
-        kompose.service.healthcheck.readiness.tcp_port: "9091"
-        kompose.service.healthcheck.readiness.timeout: 2s
+        kompose.service.healthcheck.liveness.tcp_port: "8080"
+        kompose.service.healthcheck.readiness.interval: 10s
+        kompose.service.healthcheck.readiness.retries: "5"
+        kompose.service.healthcheck.readiness.tcp_port: "9090"
+        kompose.service.healthcheck.readiness.timeout: 1s
       creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: my-group
     spec:
       containers:
-        - image: mysql
-          livenessProbe:
-            failureThreshold: 6
-            periodSeconds: 11
-            tcpSocket:
-              port: 8081
-            timeoutSeconds: 2
-          name: mysql
-          ports:
-            - containerPort: 3306
-          readinessProbe:
-            failureThreshold: 6
-            periodSeconds: 11
-            tcpSocket:
-              port: 9091
-            timeoutSeconds: 2
-          resources: {}
         - image: mongo
           livenessProbe:
             failureThreshold: 5
@@ -160,12 +143,31 @@ spec:
           name: mongo
           ports:
             - containerPort: 27017
+              protocol: TCP
           readinessProbe:
             failureThreshold: 5
             periodSeconds: 10
             tcpSocket:
               port: 9090
             timeoutSeconds: 1
+          resources: {}
+        - image: mysql
+          livenessProbe:
+            failureThreshold: 6
+            periodSeconds: 11
+            tcpSocket:
+              port: 8081
+            timeoutSeconds: 2
+          name: mysql
+          ports:
+            - containerPort: 3306
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 6
+            periodSeconds: 11
+            tcpSocket:
+              port: 9091
+            timeoutSeconds: 2
           resources: {}
       restartPolicy: Always
 status: {}
@@ -235,6 +237,7 @@ spec:
           name: postgresql
           ports:
             - containerPort: 5432
+              protocol: TCP
           readinessProbe:
             failureThreshold: 5
             httpGet:
@@ -289,6 +292,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -136,6 +136,7 @@ spec:
           name: mongo
           ports:
             - containerPort: 27017
+              protocol: TCP
           readinessProbe:
             failureThreshold: 5
             periodSeconds: 10
@@ -226,6 +227,7 @@ spec:
           name: mysql
           ports:
             - containerPort: 3306
+              protocol: TCP
           readinessProbe:
             failureThreshold: 6
             periodSeconds: 11
@@ -318,6 +320,7 @@ spec:
           name: postgresql
           ports:
             - containerPort: 5432
+              protocol: TCP
           readinessProbe:
             failureThreshold: 5
             httpGet:
@@ -408,6 +411,7 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/script/test/fixtures/service-group/output-k8s.yaml
+++ b/script/test/fixtures/service-group/output-k8s.yaml
@@ -46,6 +46,8 @@ spec:
           name: librenms
           ports:
             - containerPort: 8000
+              hostPort: 8000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /data

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -54,6 +54,8 @@ spec:
           name: front-end
           ports:
             - containerPort: 80
+              hostPort: 80
+              protocol: TCP
           resources: {}
       restartPolicy: Always
 status: {}

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -73,6 +73,8 @@ spec:
           name: db
           ports:
             - containerPort: 3306
+              hostPort: 3306
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
@@ -146,6 +148,8 @@ spec:
           name: wordpress
           ports:
             - containerPort: 80
+              hostPort: 8000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /var/www/html

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -69,6 +69,8 @@ spec:
           name: db
           ports:
             - containerPort: 3306
+              hostPort: 3306
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
@@ -127,6 +129,8 @@ spec:
           name: db
           ports:
             - containerPort: 3306
+              hostPort: 3306
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
@@ -210,6 +214,8 @@ spec:
           name: wordpress
           ports:
             - containerPort: 80
+              hostPort: 8000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /var/www/html
@@ -268,6 +274,8 @@ spec:
           name: wordpress
           ports:
             - containerPort: 80
+              hostPort: 8000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /var/www/html

--- a/script/test/fixtures/v2/output-k8s.yaml
+++ b/script/test/fixtures/v2/output-k8s.yaml
@@ -150,42 +150,81 @@ spec:
       name: foo
       ports:
         - containerPort: 6379
+          protocol: TCP
         - containerPort: 6379
           protocol: UDP
         - containerPort: 3000
+          protocol: TCP
         - containerPort: 3001
+          protocol: TCP
         - containerPort: 3002
+          protocol: TCP
         - containerPort: 3003
+          protocol: TCP
         - containerPort: 3004
+          protocol: TCP
         - containerPort: 3005
+          protocol: TCP
         - containerPort: 8000
+          hostPort: 8000
+          protocol: TCP
         - containerPort: 8080
+          hostPort: 9090
+          protocol: TCP
         - containerPort: 8081
+          hostPort: 9091
+          protocol: TCP
         - containerPort: 22
+          hostPort: 49100
+          protocol: TCP
         - containerPort: 8001
           hostIP: 127.0.0.1
+          hostPort: 8001
+          protocol: TCP
         - containerPort: 5000
           hostIP: 127.0.0.1
+          hostPort: 5000
+          protocol: TCP
         - containerPort: 5001
           hostIP: 127.0.0.1
+          hostPort: 5001
+          protocol: TCP
         - containerPort: 5002
           hostIP: 127.0.0.1
+          hostPort: 5002
+          protocol: TCP
         - containerPort: 5003
           hostIP: 127.0.0.1
+          hostPort: 5003
+          protocol: TCP
         - containerPort: 5004
           hostIP: 127.0.0.1
+          hostPort: 5004
+          protocol: TCP
         - containerPort: 5005
           hostIP: 127.0.0.1
+          hostPort: 5005
+          protocol: TCP
         - containerPort: 5006
           hostIP: 127.0.0.1
+          hostPort: 5006
+          protocol: TCP
         - containerPort: 5007
           hostIP: 127.0.0.1
+          hostPort: 5007
+          protocol: TCP
         - containerPort: 5008
           hostIP: 127.0.0.1
+          hostPort: 5008
+          protocol: TCP
         - containerPort: 5009
           hostIP: 127.0.0.1
+          hostPort: 5009
+          protocol: TCP
         - containerPort: 5010
           hostIP: 127.0.0.1
+          hostPort: 5010
+          protocol: TCP
       resources:
         limits:
           memory: "10e3"
@@ -241,7 +280,9 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
             - containerPort: 1235
+              hostPort: 1234
               protocol: UDP
           resources:
             limits:

--- a/script/test/fixtures/v2/output-os.yaml
+++ b/script/test/fixtures/v2/output-os.yaml
@@ -150,42 +150,81 @@ spec:
       name: foo
       ports:
         - containerPort: 6379
+          protocol: TCP
         - containerPort: 6379
           protocol: UDP
         - containerPort: 3000
+          protocol: TCP
         - containerPort: 3001
+          protocol: TCP
         - containerPort: 3002
+          protocol: TCP
         - containerPort: 3003
+          protocol: TCP
         - containerPort: 3004
+          protocol: TCP
         - containerPort: 3005
+          protocol: TCP
         - containerPort: 8000
+          hostPort: 8000
+          protocol: TCP
         - containerPort: 8080
+          hostPort: 9090
+          protocol: TCP
         - containerPort: 8081
+          hostPort: 9091
+          protocol: TCP
         - containerPort: 22
+          hostPort: 49100
+          protocol: TCP
         - containerPort: 8001
           hostIP: 127.0.0.1
+          hostPort: 8001
+          protocol: TCP
         - containerPort: 5000
           hostIP: 127.0.0.1
+          hostPort: 5000
+          protocol: TCP
         - containerPort: 5001
           hostIP: 127.0.0.1
+          hostPort: 5001
+          protocol: TCP
         - containerPort: 5002
           hostIP: 127.0.0.1
+          hostPort: 5002
+          protocol: TCP
         - containerPort: 5003
           hostIP: 127.0.0.1
+          hostPort: 5003
+          protocol: TCP
         - containerPort: 5004
           hostIP: 127.0.0.1
+          hostPort: 5004
+          protocol: TCP
         - containerPort: 5005
           hostIP: 127.0.0.1
+          hostPort: 5005
+          protocol: TCP
         - containerPort: 5006
           hostIP: 127.0.0.1
+          hostPort: 5006
+          protocol: TCP
         - containerPort: 5007
           hostIP: 127.0.0.1
+          hostPort: 5007
+          protocol: TCP
         - containerPort: 5008
           hostIP: 127.0.0.1
+          hostPort: 5008
+          protocol: TCP
         - containerPort: 5009
           hostIP: 127.0.0.1
+          hostPort: 5009
+          protocol: TCP
         - containerPort: 5010
           hostIP: 127.0.0.1
+          hostPort: 5010
+          protocol: TCP
       resources:
         limits:
           memory: "10e3"
@@ -223,7 +262,9 @@ spec:
           name: redis
           ports:
             - containerPort: 6379
+              protocol: TCP
             - containerPort: 1235
+              hostPort: 1234
               protocol: UDP
           resources:
             limits:

--- a/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
@@ -43,6 +43,7 @@ spec:
           name: db
           ports:
             - containerPort: 80
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: D:\config

--- a/script/test/fixtures/volume-mounts/windows/output-os.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-os.yaml
@@ -43,6 +43,7 @@ spec:
           name: db
           ports:
             - containerPort: 80
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: D:\config


### PR DESCRIPTION
Signed-off-by: AhmedGrati <ahmedgrati1999@gmail.com>

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind failing-tests
-->
Fix failing tests.

#### What this PR does / why we need it:
This PR aims to fix the functional tests by supporting `hostPort` and `protocol` in the previous tests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1585.

#### Special notes for your reviewer:
