### PR TITLE
remove build/rpm submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "build/rpm"]
-	path = build/rpm
-	url = https://src.fedoraproject.org/rpms/kompose


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

Removes the build/rpm submodule that's no longer needed / used

#### What this PR does / why we need it:

Fixes the issue of trying to build the Dockerfile: docker build -t
kompose https://github.com/kubernetes/kompose.git#main

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A

#### Special notes for your reviewer:

Signed-off-by: Charlie Drage <charlie@charliedrage.com>