### PR TITLE
chore: add configuration for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,24 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  - commit-message:
+      include: "scope"
+    directory: "/"
+    ignore:
+      # newer versions of these libs will break build
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apimachinery"
+    open-pull-requests-limit: 10
+    package-ecosystem: "gomod"
+    schedule:
+      interval: "daily"
+
+  - commit-message:
+      include: "scope"
+    directory: "/"
+    open-pull-requests-limit: 10
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

Automatically update dependencies. This is specially useful to not fall behind compose-go updates to be able to parse on the edge compose files.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1551 

#### Special notes for your reviewer:

I've not found time (and motivation frankly) to update `k8s.io/api` and `k8s.io/apimachinery` yet. I know from local test that newer versions break build and test, so we just ignore updates for them for now.