### PR TITLE
Fix openshift DeploymentConfig and ImageStream APIVersions

### DIFF
--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -79,7 +79,7 @@ func (o *OpenShift) initImageStream(name string, service kobject.ServiceConfig, 
 	is := &imageapi.ImageStream{
 		TypeMeta: kapi.TypeMeta{
 			Kind:       "ImageStream",
-			APIVersion: "v1",
+			APIVersion: "image.openshift.io/v1",
 		},
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,
@@ -172,7 +172,7 @@ func (o *OpenShift) initDeploymentConfig(name string, service kobject.ServiceCon
 	dc := &deployapi.DeploymentConfig{
 		TypeMeta: kapi.TypeMeta{
 			Kind:       "DeploymentConfig",
-			APIVersion: "v1",
+			APIVersion: "apps.openshift.io/v1",
 		},
 		ObjectMeta: kapi.ObjectMeta{
 			Name:   name,

--- a/pkg/transformer/openshift/openshift_test.go
+++ b/pkg/transformer/openshift/openshift_test.go
@@ -105,6 +105,11 @@ func TestInitDeploymentConfig(t *testing.T) {
 	if spec.Spec.Triggers[1].ImageChangeParams.ContainerNames[0] != "myfoobarname" {
 		t.Errorf("Expected myfoobarname for name, actual %s", spec.Spec.Triggers[1].ImageChangeParams.ContainerNames[0])
 	}
+
+	// Check that the APIVersion is equal to "apps.openshift.io/v1"
+	if spec.APIVersion != "apps.openshift.io/v1" {
+		t.Errorf("Expected 'apps.openshift.io/v1' for APIVersion, actual %s", spec.APIVersion)
+	}
 }
 
 func TestKomposeConvertRoute(t *testing.T) {

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -232,6 +232,7 @@ os_cmd="kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/exter
 os_output="$KOMPOSE_ROOT/script/test/fixtures/external-traffic-policy/output-os-v1.yaml"
 convert::expect_success_and_warning "$k8s_cmd" "$k8s_output"
 convert::expect_success "$os_cmd" "$os_output"
+
 # Test external traffic policy feature with warning, because we have nodeport with external traffic policy
 k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/external-traffic-policy/docker-compose-v2.yaml convert --stdout --with-kompose-annotation=false"
 k8s_output="$KOMPOSE_ROOT/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml"

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -38,7 +38,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -85,7 +85,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -109,7 +109,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -168,7 +168,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -38,7 +38,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -85,7 +85,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -109,7 +109,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -138,6 +138,8 @@ spec:
           name: web
           ports:
             - containerPort: 5000
+              hostPort: 5000
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /code
@@ -166,7 +168,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -58,7 +58,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -95,7 +95,7 @@ metadata:
   name: db-cm0
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -159,7 +159,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/configmap-volume/output-os.yaml
+++ b/script/test/fixtures/configmap-volume/output-os.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -56,7 +56,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -93,7 +93,7 @@ metadata:
   name: db-cm0
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -155,7 +155,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/deploy/placement/output-placement-os.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-os.yaml
@@ -17,7 +17,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -95,7 +95,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/envvars-interpolation/output-os.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-os.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -52,7 +52,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -39,7 +39,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -87,7 +87,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -111,7 +111,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -164,7 +164,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -24,7 +24,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -81,7 +81,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -24,7 +24,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -81,7 +81,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -98,7 +98,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -165,7 +165,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -189,7 +189,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -256,7 +256,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -280,7 +280,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -350,7 +350,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -374,7 +374,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -442,7 +442,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/host-port-protocol/output-os.yaml
+++ b/script/test/fixtures/host-port-protocol/output-os.yaml
@@ -17,7 +17,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -66,7 +66,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/multiple-files/output-os.yaml
+++ b/script/test/fixtures/multiple-files/output-os.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -44,7 +44,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -68,7 +68,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -113,7 +113,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/multiple-type-volumes/output-os.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-os.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -54,7 +54,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -94,7 +94,7 @@ spec:
 status: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -158,7 +158,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -94,7 +94,7 @@ status:
   replicas: 0
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -156,7 +156,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -239,7 +239,7 @@ status:
   replicas: 0
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -301,7 +301,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null

--- a/script/test/fixtures/v3.0/output-os.yaml
+++ b/script/test/fixtures/v3.0/output-os.yaml
@@ -20,7 +20,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -71,7 +71,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -95,7 +95,7 @@ status:
   dockerImageRepository: ""
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
@@ -149,7 +149,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null
@@ -171,3 +171,4 @@ spec:
         type: ""
 status:
   dockerImageRepository: ""
+

--- a/script/test/fixtures/volume-mounts/windows/output-os.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-os.yaml
@@ -17,7 +17,7 @@ status:
   loadBalancer: {}
 
 ---
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   creationTimestamp: null
@@ -73,7 +73,7 @@ status:
   updatedReplicas: 0
 
 ---
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
It updates the API versions of Openshift DeploymentConfig and ImageStream resources, to match the current version.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1597.

#### Special notes for your reviewer:
