### PR TITLE
fix: enable compose environment variables interpolation

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -156,7 +156,7 @@ func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
 		return kobject.KomposeObject{}, err
 	}
 
-	projectOptions, err := cli.NewProjectOptions(files, cli.WithOsEnv, cli.WithWorkingDirectory(workingDir), cli.WithInterpolation(false))
+	projectOptions, err := cli.NewProjectOptions(files, cli.WithOsEnv, cli.WithWorkingDirectory(workingDir), cli.WithInterpolation(true))
 	if err != nil {
 		return kobject.KomposeObject{}, errors.Wrap(err, "Unable to create compose options")
 	}

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -249,6 +249,11 @@ os_output="$KOMPOSE_ROOT/script/test/fixtures/fsgroup/output-os.yaml"
 convert::expect_success_and_warning "$k8s_cmd" "$k8s_output"
 
 # Test support for compose.yaml file
-k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/compose-file-support convert --stdout --with-kompose-annotation=false"
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/compose-file-support/docker-compose.yaml convert --stdout --with-kompose-annotation=false"
 k8s_output="$KOMPOSE_ROOT/script/test/fixtures/compose-file-support/output-k8s.yaml"
-convert::expect_success "$os_cmd" "$os_output"
+convert::expect_success "$k8s_cmd" "$k8s_output"
+
+# Test support for compose env interpolation
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/compose-env-interpolation/docker-compose.yaml convert --stdout --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/compose-env-interpolation/output-k8s.yaml"
+convert::expect_success "$k8s_cmd" "$k8s_output"

--- a/script/test/fixtures/compose-env-interpolation/docker-compose.yaml
+++ b/script/test/fixtures/compose-env-interpolation/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  foo:
+    labels:
+      kompose.image-pull-policy: "${IMAGE_PULL_POLICY:-IfNotPresent}"
+    build: .

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.image-pull-policy: IfNotPresent
+  creationTimestamp: null
+  labels:
+    io.kompose.service: foo
+  name: foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: foo
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.image-pull-policy: IfNotPresent
+      creationTimestamp: null
+      labels:
+        io.kompose.network/compose-env-interpolation-default: "true"
+        io.kompose.service: foo
+    spec:
+      containers:
+        - image: foo
+          imagePullPolicy: IfNotPresent
+          name: foo
+          resources: {}
+      restartPolicy: Always
+status: {}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  name: compose-env-interpolation-default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              io.kompose.network/compose-env-interpolation-default: "true"
+  podSelector:
+    matchLabels:
+      io.kompose.network/compose-env-interpolation-default: "true"
+


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
Enabling the environment variables interpolation in the compose spec.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1634.

#### Special notes for your reviewer:
