### PR TITLE
fix missing image pull secrets

### DIFF
--- a/pkg/transformer/kubernetes/podspec.go
+++ b/pkg/transformer/kubernetes/podspec.go
@@ -48,7 +48,11 @@ func AddContainer(service kobject.ServiceConfig, opt kobject.ConvertOptions) Pod
 			LivenessProbe:  configProbe(service.HealthChecks.Liveness),
 			ReadinessProbe: configProbe(service.HealthChecks.Readiness),
 		})
-
+		if service.ImagePullSecret != "" {
+			podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, api.LocalObjectReference{
+				Name: service.ImagePullSecret,
+			})
+		}
 		podSpec.Affinity = ConfigAffinity(service)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
Fix missing image pull secrets whenever we use multiple containers in the same deployment.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1645.

#### Special notes for your reviewer:
