### PR TITLE
Feat: add read only containers support

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -110,6 +110,7 @@ type ServiceConfig struct {
 	WorkingDir                    string             `compose:""`
 	DomainName                    string             `compose:"domainname"`
 	HostName                      string             `compose:"hostname"`
+	ReadOnly                      bool               `compose:"read_only"`
 	Args                          []string           `compose:"args"`
 	VolList                       []string           `compose:"volumes"`
 	Network                       []string           `compose:"network"`

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -462,6 +462,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 		serviceConfig.Expose = composeServiceConfig.Expose
 		serviceConfig.Privileged = composeServiceConfig.Privileged
 		serviceConfig.User = composeServiceConfig.User
+		serviceConfig.ReadOnly = composeServiceConfig.ReadOnly
 		serviceConfig.Stdin = composeServiceConfig.StdinOpen
 		serviceConfig.Tty = composeServiceConfig.Tty
 		serviceConfig.TmpFs = composeServiceConfig.Tmpfs

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -573,6 +573,11 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 			securityContext.Capabilities = capabilities
 		}
 
+		//set readOnlyRootFilesystem if it is enabled
+		if service.ReadOnly {
+			securityContext.ReadOnlyRootFilesystem = &service.ReadOnly
+		}
+
 		// update template only if securityContext is not empty
 		if *securityContext != (api.SecurityContext{}) {
 			template.Spec.Containers[0].SecurityContext = securityContext

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -277,3 +277,11 @@ convert::expect_success "$os_cmd" "$os_output"
 k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/custom-build-push/docker-compose.yaml convert --build-command 'docker build -t ahmedgrati/kompose-test ./script/test/fixtures/custom-build-push' --push-command 'docker push ahmedgrati/kompose-test' --stdout --with-kompose-annotation=false"
 k8s_output="$KOMPOSE_ROOT/script/test/fixtures/custom-build-push/output-k8s.yaml"
 convert::expect_success "$os_cmd" "$os_output"
+
+# Test support for read only root fs
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/read-only/docker-compose.yaml convert --stdout --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/read-only/output-k8s.yaml"
+os_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/read-only/docker-compose.yaml convert --stdout --with-kompose-annotation=false --provider openshift"
+os_output="$KOMPOSE_ROOT/script/test/fixtures/read-only/output-os.yaml"
+convert::expect_success "$k8s_cmd" "$k8s_output"
+convert::expect_success "$os_cmd" "$os_output"

--- a/script/test/fixtures/read-only/docker-compose.yaml
+++ b/script/test/fixtures/read-only/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  test:
+    image: alpine
+    read_only: true
+    ports:
+    - 80:80

--- a/script/test/fixtures/read-only/output-k8s.yaml
+++ b/script/test/fixtures/read-only/output-k8s.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: test
+  name: test
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: test
+status:
+  loadBalancer: {}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: test
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/read-only-default: "true"
+        io.kompose.service: test
+    spec:
+      containers:
+        - image: alpine
+          name: test
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          resources: {}
+          securityContext:
+            readOnlyRootFilesystem: true
+      restartPolicy: Always
+status: {}
+

--- a/script/test/fixtures/read-only/output-os.yaml
+++ b/script/test/fixtures/read-only/output-os.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: test
+  name: test
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: test
+status:
+  loadBalancer: {}
+
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    io.kompose.service: test
+  strategy:
+    resources: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/read-only-default: "true"
+        io.kompose.service: test
+    spec:
+      containers:
+        - image: ' '
+          name: test
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          resources: {}
+          securityContext:
+            readOnlyRootFilesystem: true
+      restartPolicy: Always
+  test: false
+  triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - test
+        from:
+          kind: ImageStreamTag
+          name: test:latest
+      type: ImageChange
+status:
+  availableReplicas: 0
+  latestVersion: 0
+  observedGeneration: 0
+  replicas: 0
+  unavailableReplicas: 0
+  updatedReplicas: 0
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: test
+  name: test
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: alpine
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+status:
+  dockerImageRepository: ""
+


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What this PR does / why we need it:
Support `SecurityContext.ReadOnlyRootFileSystem` through the docker_compose `read_only` attribute.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1668.

#### Special notes for your reviewer:
