### PR TITLE
update redis wording to replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Convert [`docker-compose.yaml`](https://raw.githubusercontent.com/kubernetes/kom
 $ kompose convert -f docker-compose.yaml
 INFO Kubernetes file "frontend-service.yaml" created
 INFO Kubernetes file "redis-master-service.yaml" created
-INFO Kubernetes file "redis-slave-service.yaml" created
+INFO Kubernetes file "redis-replica-service.yaml" created
 INFO Kubernetes file "frontend-deployment.yaml" created
 INFO Kubernetes file "redis-master-deployment.yaml" created
-INFO Kubernetes file "redis-slave-deployment.yaml" created
+INFO Kubernetes file "redis-replica-deployment.yaml" created
 ```
 
 Other examples are provided in the _examples_ [directory](./examples).

--- a/examples/docker-compose-v3.yaml
+++ b/examples/docker-compose-v3.yaml
@@ -3,19 +3,19 @@ version: "3"
 services:
 
   redis-master:
-    image: registry.k8s.io/redis:e2e 
+    image: registry.k8s.io/redis:e2e
     ports:
       - "6379"
 
-  redis-slave:
-    image: gcr.io/google_samples/gb-redisslave:v1
+  redis-replica:
+    image: registry.k8s.io/redis-slave:v2
     ports:
       - "6379"
     environment:
       - GET_HOSTS_FROM=dns
 
   frontend:
-    image: gcr.io/google-samples/gb-frontend:v4
+    image: registry.k8s.io/guestbook:v3
     ports:
       - "80:80"
     environment:

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -7,15 +7,16 @@ services:
     ports:
       - "6379"
 
-  redis-slave:
-    image: gcr.io/google_samples/gb-redisslave:v1
+  redis-replica:
+    image: registry.k8s.io/redis-slave:v2
+
     ports:
       - "6379"
     environment:
       - GET_HOSTS_FROM=dns
 
   frontend:
-    image: gcr.io/google-samples/gb-frontend:v4
+    image: registry.k8s.io/guestbook:v3
     ports:
       - "80:80"
     environment:

--- a/script/test/fixtures/controller/docker-compose.yml
+++ b/script/test/fixtures/controller/docker-compose.yml
@@ -7,15 +7,15 @@ services:
     ports:
       - "6379"
 
-  redis-slave:
-    image: gcr.io/google_samples/gb-redisslave:v1
+  redis-replica:
+    image: registry.k8s.io/redis-slave:v2
     ports:
       - "6379"
     environment:
       - GET_HOSTS_FROM=dns
 
   frontend:
-    image: gcr.io/google-samples/gb-frontend:v4
+    image: registry.k8s.io/guestbook:v3
     ports:
       - "80:80"
     environment:

--- a/script/test/fixtures/controller/output-k8s-daemonset-template.json
+++ b/script/test/fixtures/controller/output-k8s-daemonset-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -208,16 +208,16 @@
         },
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
-        "name": "redis-slave"
+        "name": "redis-replica"
       },
       "spec": {
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
@@ -229,9 +229,9 @@
                     "value": "dns"
                   }
                 ],
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "imagePullPolicy": "",
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/controller/output-k8s-deployment-template.json
+++ b/script/test/fixtures/controller/output-k8s-deployment-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -223,15 +223,15 @@
         },
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
-        "name": "redis-slave"
+        "name": "redis-replica"
       },
       "spec": {
         "replicas": 1,
         "selector": {
           "matchLabels": {
-            "io.kompose.service": "redis-slave"
+            "io.kompose.service": "redis-replica"
           }
         },
         "strategy": {},
@@ -243,7 +243,7 @@
             },
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
@@ -255,9 +255,9 @@
                     "value": "dns"
                   }
                 ],
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "imagePullPolicy": "",
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/controller/output-k8s-rc-template.json
+++ b/script/test/fixtures/controller/output-k8s-rc-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -194,10 +194,10 @@
       "kind": "ReplicationController",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -210,14 +210,14 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-slave",
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "name": "redis-replica",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/examples/output-k8s.json
+++ b/script/test/fixtures/examples/output-k8s.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -201,10 +201,10 @@
       "kind": "Deployment",
       "apiVersion": "apps/v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -217,7 +217,7 @@
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             },
             "annotations": {
               "kompose.cmd": "%CMD%",
@@ -227,8 +227,8 @@
           "spec": {
             "containers": [
               {
-                "name": "redis-slave",
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "name": "redis-replica",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/examples/output-os.json
+++ b/script/test/fixtures/examples/output-os.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -296,10 +296,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -319,11 +319,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "redis-slave"
+                "redis-replica"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "redis-slave:v1"
+                "name": "redis-replica:v1"
               }
             }
           }
@@ -331,19 +331,19 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "image": " ",
                 "ports": [
                   {
@@ -369,10 +369,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "spec": {
@@ -382,7 +382,7 @@
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "gcr.io/google_samples/gb-redisslave:v1"
+              "name": "registry.k8s.io/redis-slave:v2"
             },
             "generation": null,
             "importPolicy": {}

--- a/script/test/fixtures/examples/output-v3-k8s.json
+++ b/script/test/fixtures/examples/output-v3-k8s.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -223,15 +223,15 @@
         },
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
-        "name": "redis-slave"
+        "name": "redis-replica"
       },
       "spec": {
         "replicas": 1,
         "selector": {
           "matchLabels": {
-            "io.kompose.service": "redis-slave"
+            "io.kompose.service": "redis-replica"
           }
         },
         "strategy": {},
@@ -243,7 +243,7 @@
             },
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
@@ -255,9 +255,9 @@
                     "value": "dns"
                   }
                 ],
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "imagePullPolicy": "",
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/examples/output-v3-os.json
+++ b/script/test/fixtures/examples/output-v3-os.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -296,10 +296,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -319,11 +319,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "redis-slave"
+                "redis-replica"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "redis-slave:v1"
+                "name": "redis-replica:v1"
               }
             }
           }
@@ -331,19 +331,19 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "image": " ",
                 "ports": [
                   {
@@ -369,10 +369,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "spec": {
@@ -382,7 +382,7 @@
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "gcr.io/google_samples/gb-redisslave:v1"
+              "name": "registry.k8s.io/redis-slave:v2"
             },
             "generation": null,
             "importPolicy": {}

--- a/script/test/fixtures/keyonly-envs/env.yml
+++ b/script/test/fixtures/keyonly-envs/env.yml
@@ -5,8 +5,8 @@ services:
     image: registry.k8s.io/redis:e2e 
     ports:
       - "6379"
-  redis-slave:
-    image: gcr.io/google_samples/gb-redisslave:v1
+  redis-replica:
+    image: registry.k8s.io/redis-slave:v2
     ports:
       - "6379"
     environment:

--- a/script/test/fixtures/keyonly-envs/output-k8s-template.json
+++ b/script/test/fixtures/keyonly-envs/output-k8s-template.json
@@ -67,10 +67,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -86,7 +86,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -231,15 +231,15 @@
         },
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
-        "name": "redis-slave"
+        "name": "redis-replica"
       },
       "spec": {
         "replicas": 1,
         "selector": {
           "matchLabels": {
-            "io.kompose.service": "redis-slave"
+            "io.kompose.service": "redis-replica"
           }
         },
         "strategy": {},
@@ -251,7 +251,7 @@
             },
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
@@ -275,9 +275,9 @@
                     "value": "true"
                   }
                 ],
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "imagePullPolicy": "",
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/unused/v3/docker-compose.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose.yaml
@@ -7,8 +7,8 @@ services:
     ports:
       - "6379"
 
-  redis-slave:
-    image: gcr.io/google_samples/gb-redisslave:v1
+  redis-replica:
+    image: registry.k8s.io/redis-slave:v2
     ports:
       - "6379"
     environment:

--- a/script/test/fixtures/unused/v3/output-k8s-template.json
+++ b/script/test/fixtures/unused/v3/output-k8s-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -223,15 +223,15 @@
         },
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
-        "name": "redis-slave"
+        "name": "redis-replica"
       },
       "spec": {
         "replicas": 1,
         "selector": {
           "matchLabels": {
-            "io.kompose.service": "redis-slave"
+            "io.kompose.service": "redis-replica"
           }
         },
         "strategy": {},
@@ -243,7 +243,7 @@
             },
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
@@ -255,9 +255,9 @@
                     "value": "dns"
                   }
                 ],
-                "image": "gcr.io/google_samples/gb-redisslave:v1",
+                "image": "registry.k8s.io/redis-slave:v2",
                 "imagePullPolicy": "",
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "ports": [
                   {
                     "containerPort": 6379

--- a/script/test/fixtures/unused/v3/output-os-template.json
+++ b/script/test/fixtures/unused/v3/output-os-template.json
@@ -69,10 +69,10 @@
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -88,7 +88,7 @@
           }
         ],
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "status": {
@@ -296,10 +296,10 @@
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "annotations": {
           "kompose.cmd": "%CMD%",
@@ -319,11 +319,11 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "redis-slave"
+                "redis-replica"
               ],
               "from": {
                 "kind": "ImageStreamTag",
-                "name": "redis-slave:v1"
+                "name": "redis-replica:v1"
               }
             }
           }
@@ -331,19 +331,19 @@
         "replicas": 1,
         "test": false,
         "selector": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         },
         "template": {
           "metadata": {
             "creationTimestamp": null,
             "labels": {
-              "io.kompose.service": "redis-slave"
+              "io.kompose.service": "redis-replica"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "redis-slave",
+                "name": "redis-replica",
                 "image": " ",
                 "ports": [
                   {
@@ -369,10 +369,10 @@
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
-        "name": "redis-slave",
+        "name": "redis-replica",
         "creationTimestamp": null,
         "labels": {
-          "io.kompose.service": "redis-slave"
+          "io.kompose.service": "redis-replica"
         }
       },
       "spec": {
@@ -382,7 +382,7 @@
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "gcr.io/google_samples/gb-redisslave:v1"
+              "name": "registry.k8s.io/redis-slave:v2"
             },
             "generation": null,
             "importPolicy": {}


### PR DESCRIPTION
update redis wording to replica

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

We should be using replica to indicate a new node of redis.

Unfortunatley gcr still hasn't pushed another image, so we will still
have to use registry.k8s.io/redis-slave:v2

#### What this PR does / why we need it:

N/A

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

N/A

#### Special notes for your reviewer:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
