### PR TITLE
Fix expose conversion

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -288,7 +288,6 @@ func loadPorts(ports []types.ServicePortConfig, expose []string) []kobject.Ports
 			continue
 		}
 		komposePorts = append(komposePorts, kobject.Ports{
-			HostPort:      cast.ToInt32(portValue),
 			ContainerPort: cast.ToInt32(portValue),
 			HostIP:        "",
 			Protocol:      strings.ToUpper(protocol),

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -221,7 +221,7 @@ func TestLoadV3Ports(t *testing.T) {
 			expose: []string{"80", "8080"},
 			want: []kobject.Ports{
 				{HostPort: 80, ContainerPort: 80, Protocol: string(api.ProtocolTCP)},
-				{HostPort: 8080, ContainerPort: 8080, Protocol: string(api.ProtocolTCP)},
+				{ContainerPort: 8080, Protocol: string(api.ProtocolTCP)},
 			},
 		},
 		{
@@ -230,7 +230,7 @@ func TestLoadV3Ports(t *testing.T) {
 			expose: []string{"80/udp"},
 			want: []kobject.Ports{
 				{HostPort: 80, ContainerPort: 80, Protocol: string(api.ProtocolTCP)},
-				{HostPort: 80, ContainerPort: 80, Protocol: string(api.ProtocolUDP)},
+				{ContainerPort: 80, Protocol: string(api.ProtocolUDP)},
 			},
 		},
 	} {
@@ -347,8 +347,8 @@ func TestLoadPorts(t *testing.T) {
 			want: []kobject.Ports{
 				{ContainerPort: 80, Protocol: string(api.ProtocolTCP)},
 				{ContainerPort: 3000, Protocol: string(api.ProtocolTCP)},
-				{HostPort: 80, ContainerPort: 80, Protocol: string(api.ProtocolTCP)},
-				{HostPort: 8080, ContainerPort: 8080, Protocol: string(api.ProtocolTCP)},
+				{ContainerPort: 80, Protocol: string(api.ProtocolTCP)},
+				{ContainerPort: 8080, Protocol: string(api.ProtocolTCP)},
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
Fix the `expose` conversion in the `pkg/loader/compose/compose.go`, where we should not add the exposed ports as HostPort in the Containers' port inside the Kubernetes pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1691.

#### Special notes for your reviewer:
