### PR TITLE
feat: adding support for --profile cmd option

### DIFF
--- a/client/convert.go
+++ b/client/convert.go
@@ -33,6 +33,7 @@ func (k *Kompose) Convert(options ConvertOptions) ([]runtime.Object, error) {
 		PushImageRegistry:           options.PushImageRegistry,
 		CreateDeploymentConfig:      k.createDeploymentConfig(options),
 		EmptyVols:                   false,
+		Profiles:                    options.Profiles,
 		Volumes:                     *options.VolumeType,
 		PVCRequestSize:              options.PvcRequestSize,
 		InsecureRepository:          k.insecureRepository(options),

--- a/client/convert_test.go
+++ b/client/convert_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"sort"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -69,7 +71,7 @@ func TestConvertWithDefaultOptions(t *testing.T) {
 	client, err := NewClient(WithErrorOnWarning())
 	assert.Check(t, is.Equal(err, nil))
 	objects, err := client.Convert(ConvertOptions{
-		OutFile: "./testdata/generated/",
+		ToStdout: true,
 		InputFiles: []string{
 			"./testdata/docker-compose.yaml",
 		},
@@ -79,5 +81,91 @@ func TestConvertWithDefaultOptions(t *testing.T) {
 		if deployment, ok := object.(*appsv1.Deployment); ok {
 			assert.Check(t, is.Equal(int(*deployment.Spec.Replicas), 1))
 		}
+	}
+}
+
+func TestConvertWithProfiles(t *testing.T) {
+	client, err := NewClient(WithErrorOnWarning())
+	assert.Check(t, is.Equal(err, nil))
+
+	type Want struct {
+		deploymentsNames []string
+		servicesNames    []string
+	}
+
+	tests := []struct {
+		name    string
+		options ConvertOptions
+		want    Want
+	}{
+		{
+			name: "No profiles provided",
+			options: ConvertOptions{
+				ToStdout: true,
+				InputFiles: []string{
+					"./testdata/docker-compose-profiles.yaml",
+				},
+			},
+			want: Want{
+				deploymentsNames: nil,
+				servicesNames:    nil,
+			},
+		},
+		{
+			name: "All profiles provided",
+			options: ConvertOptions{
+				ToStdout: true,
+				InputFiles: []string{
+					"./testdata/docker-compose-profiles.yaml",
+				},
+				Profiles: []string{"hello", "world"},
+			},
+			want: Want{
+				deploymentsNames: []string{"backend", "frontend", "database"},
+				servicesNames:    []string{"backend", "frontend", "database"},
+			},
+		},
+		{
+			name: "All profiles provided",
+			options: ConvertOptions{
+				ToStdout: true,
+				InputFiles: []string{
+					"./testdata/docker-compose-profiles.yaml",
+				},
+				Profiles: []string{"hello"},
+			},
+			want: Want{
+				deploymentsNames: []string{"backend", "frontend"},
+				servicesNames:    []string{"backend", "frontend"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects, err := client.Convert(tt.options)
+			assert.Check(t, is.Equal(err, nil))
+
+			sort.Strings(tt.want.deploymentsNames)
+			sort.Strings(tt.want.servicesNames)
+
+			var deploymentsNames []string
+			var servicesNames []string
+
+			for _, object := range objects {
+				if deployment, ok := object.(*appsv1.Deployment); ok {
+					deploymentsNames = append(deploymentsNames, deployment.Name)
+				}
+
+				if service, ok := object.(*v1.Service); ok {
+					servicesNames = append(servicesNames, service.Name)
+				}
+			}
+
+			sort.Strings(deploymentsNames)
+			sort.Strings(servicesNames)
+
+			assert.Check(t, is.DeepEqual(deploymentsNames, tt.want.deploymentsNames))
+			assert.Check(t, is.DeepEqual(servicesNames, tt.want.servicesNames))
+		})
 	}
 }

--- a/client/convert_test.go
+++ b/client/convert_test.go
@@ -126,7 +126,7 @@ func TestConvertWithProfiles(t *testing.T) {
 			},
 		},
 		{
-			name: "All profiles provided",
+			name: "One profile only",
 			options: ConvertOptions{
 				ToStdout: true,
 				InputFiles: []string{

--- a/client/testdata/docker-compose-profiles.yaml
+++ b/client/testdata/docker-compose-profiles.yaml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  backend:
+    image: dummy:tag
+    profiles: ['hello', 'world']
+    ports:
+      - "80:80"
+  frontend:
+    image: dummy:tag
+    profiles: [ 'hello' ]
+    ports:
+      - "80:80"
+  database:
+    image: dummy:tag
+    profiles: [ 'world' ]
+    ports:
+      - "80:80"

--- a/client/types.go
+++ b/client/types.go
@@ -44,6 +44,7 @@ type ConvertOptions struct {
 	PvcRequestSize         string
 	WithKomposeAnnotations *bool
 	InputFiles             []string
+	Profiles               []string
 	Provider
 	GenerateNetworkPolicies bool
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -201,7 +201,7 @@ func init() {
 
 	convertCmd.Flags().IntVar(&ConvertYAMLIndent, "indent", 2, "Spaces length to indent generated yaml files")
 
-	convertCmd.Flags().StringArrayVar(&ConvertProfiles, "profile", []string{}, `Specify the profile to use, can use multiple.`)
+	convertCmd.Flags().StringArrayVar(&ConvertProfiles, "profile", []string{}, `Specify the profile to use, can use multiple profiles`)
 
 	// In order to 'separate' both OpenShift and Kubernetes only flags. A custom help page is created
 	customHelp := `Usage:{{if .Runnable}}

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -46,6 +46,7 @@ var (
 	ConvertDeploymentConfig      bool
 	ConvertReplicas              int
 	ConvertController            string
+	ConvertProfiles              []string
 	ConvertPushImage             bool
 	ConvertNamespace             string
 	ConvertPushImageRegistry     string
@@ -115,6 +116,7 @@ var convertCmd = &cobra.Command{
 			IsReplicaSetFlag:            cmd.Flags().Lookup("replicas").Changed,
 			IsDeploymentConfigFlag:      cmd.Flags().Lookup("deployment-config").Changed,
 			YAMLIndent:                  ConvertYAMLIndent,
+			Profiles:                    ConvertProfiles,
 			WithKomposeAnnotation:       WithKomposeAnnotation,
 			MultipleContainerMode:       MultipleContainerMode,
 			ServiceGroupMode:            ServiceGroupMode,
@@ -198,6 +200,8 @@ func init() {
 	convertCmd.Flags().MarkDeprecated("emptyvols", "emptyvols has been marked as deprecated. Use --volumes emptyDir")
 
 	convertCmd.Flags().IntVar(&ConvertYAMLIndent, "indent", 2, "Spaces length to indent generated yaml files")
+
+	convertCmd.Flags().StringArrayVar(&ConvertProfiles, "profile", []string{}, `Specify the profile to use, can use multiple.`)
 
 	// In order to 'separate' both OpenShift and Kubernetes only flags. A custom help page is created
 	customHelp := `Usage:{{if .Runnable}}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -217,7 +217,7 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 	komposeObject := kobject.KomposeObject{
 		ServiceConfigs: make(map[string]kobject.ServiceConfig),
 	}
-	komposeObject, err = l.LoadFile(opt.InputFiles)
+	komposeObject, err = l.LoadFile(opt.InputFiles, opt.Profiles)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -118,7 +118,6 @@ type ServiceConfig struct {
 	Args                          []string           `compose:"args"`
 	VolList                       []string           `compose:"volumes"`
 	Network                       []string           `compose:"network"`
-	Profiles                      []string           `compose:"profiles"`
 	Labels                        map[string]string  `compose:"labels"`
 	Annotations                   map[string]string  `compose:""`
 	CPUSet                        string             `compose:"cpuset"`

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -53,6 +53,7 @@ type ConvertOptions struct {
 	BuildRepo                   string
 	BuildBranch                 string
 	Build                       string
+	Profiles                    []string
 	PushImage                   bool
 	PushImageRegistry           string
 	CreateChart                 bool
@@ -117,6 +118,7 @@ type ServiceConfig struct {
 	Args                          []string           `compose:"args"`
 	VolList                       []string           `compose:"volumes"`
 	Network                       []string           `compose:"network"`
+	Profiles                      []string           `compose:"profiles"`
 	Labels                        map[string]string  `compose:"labels"`
 	Annotations                   map[string]string  `compose:""`
 	CPUSet                        string             `compose:"cpuset"`

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -467,7 +467,6 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 		serviceConfig.Privileged = composeServiceConfig.Privileged
 		serviceConfig.User = composeServiceConfig.User
 		serviceConfig.ReadOnly = composeServiceConfig.ReadOnly
-		serviceConfig.Profiles = []string{"frontend-dev"}
 		serviceConfig.Stdin = composeServiceConfig.StdinOpen
 		serviceConfig.Tty = composeServiceConfig.Tty
 		serviceConfig.TmpFs = composeServiceConfig.Tmpfs

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -149,14 +149,19 @@ func checkUnsupportedKey(composeProject *types.Project) []string {
 }
 
 // LoadFile loads a compose file into KomposeObject
-func (c *Compose) LoadFile(files []string) (kobject.KomposeObject, error) {
+func (c *Compose) LoadFile(files []string, profiles []string) (kobject.KomposeObject, error) {
 	// Gather the working directory
 	workingDir, err := getComposeFileDir(files)
 	if err != nil {
 		return kobject.KomposeObject{}, err
 	}
 
-	projectOptions, err := cli.NewProjectOptions(files, cli.WithOsEnv, cli.WithWorkingDirectory(workingDir), cli.WithInterpolation(true))
+	projectOptions, err := cli.NewProjectOptions(
+		files, cli.WithOsEnv,
+		cli.WithWorkingDirectory(workingDir),
+		cli.WithInterpolation(true),
+		cli.WithProfiles(profiles),
+	)
 	if err != nil {
 		return kobject.KomposeObject{}, errors.Wrap(err, "Unable to create compose options")
 	}
@@ -462,6 +467,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 		serviceConfig.Privileged = composeServiceConfig.Privileged
 		serviceConfig.User = composeServiceConfig.User
 		serviceConfig.ReadOnly = composeServiceConfig.ReadOnly
+		serviceConfig.Profiles = []string{"frontend-dev"}
 		serviceConfig.Stdin = composeServiceConfig.StdinOpen
 		serviceConfig.Tty = composeServiceConfig.Tty
 		serviceConfig.TmpFs = composeServiceConfig.Tmpfs

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -25,7 +25,7 @@ import (
 
 // Loader interface defines loader that loads files and converts it to kobject representation
 type Loader interface {
-	LoadFile(files []string) (kobject.KomposeObject, error)
+	LoadFile(files []string, profiles []string) (kobject.KomposeObject, error)
 	///Name() string
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
-->
/kind feature

#### What this PR does / why we need it:

When using docker compose we can use the [profiles](https://docs.docker.com/compose/compose-file/05-services/#profiles) attribute. 

> profiles defines a list of named profiles for the service to be enabled under. If unassigned, the service is always started but if assigned, it is only started if the profile is activated.

In the current behaviour of kompose, if the compose file is using profiles, it will not process the services. This PR allows to add the `--profile` cmd command (repeatable) to send a list of string to the loader, that will be able to process the file and enable the services.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes/kompose/issues/1708 https://github.com/kubernetes/kompose/issues/1458 https://github.com/kubernetes/kompose/issues/1448

#### Special notes for your reviewer: