### PR TITLE
bug: fixes bug with error out with using kompose convert with no -f

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -133,7 +133,12 @@ var convertCmd = &cobra.Command{
 		}
 
 		app.ValidateFlags(args, cmd, &ConvertOpt)
-		app.ValidateComposeFile(&ConvertOpt)
+
+		// Since ValidateComposeFiles returns an error, let's validate it and output the error appropriately if the validation fails
+		err := app.ValidateComposeFile(&ConvertOpt)
+		if err != nil {
+			log.Fatalf("Error validating compose file: %v", err)
+		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -146,18 +146,18 @@ func ValidateFlags(args []string, cmd *cobra.Command, opt *kobject.ConvertOption
 // ValidateComposeFile validates the compose file provided for conversion
 func ValidateComposeFile(opt *kobject.ConvertOptions) error {
 	if len(opt.InputFiles) == 0 {
+		// Go through a range of "default" file names to see if tany ofthem exist in the current directory
 		for _, name := range DefaultComposeFiles {
 			_, err := os.Stat(name)
 			if err != nil {
 				log.Debugf("'%s' not found: %v", name, err)
-				return err
 			} else {
 				opt.InputFiles = []string{name}
 				return nil
 			}
 		}
-
-		log.Fatal("No 'docker-compose' file found")
+		// Return an error message that no compose or docker-compose yaml files were found
+		return fmt.Errorf("No compose or docker-compose yaml file found in the current directory")
 	}
 	return nil
 }


### PR DESCRIPTION
bug: fixes bug with error out with using kompose convert with no -f

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

Fixes a validation bug where if you do not provide a compose.yaml or
docker-compose.yaml it will nil point error out rather than have an
appropriate "file not found" output.

It was also going through the list of valid files (compose.yaml, compose.yml), |
but only failing after the first one wasn't found..

So if someone had a docker-compose.yaml file, it'd fail. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Closes https://github.com/kubernetes/kompose/issues/1719

#### Special notes for your reviewer:

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
