### PR TITLE
only add namespace if specified

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1601,7 +1601,11 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 	// sort all object so Services are first
 	k.SortServicesFirst(&allobjects)
 	k.RemoveDupObjects(&allobjects)
-	transformer.AssignNamespaceToObjects(&allobjects, komposeObject.Namespace)
+
+	// Only append namespaces if --namespace has been passed in
+	if komposeObject.Namespace != "" {
+		transformer.AssignNamespaceToObjects(&allobjects, komposeObject.Namespace)
+	}
 	// k.FixWorkloadVersion(&allobjects)
 	return allobjects, nil
 }

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -1119,3 +1119,29 @@ func TestNamespaceGeneration(t *testing.T) {
 		}
 	}
 }
+
+// Test namespace generation with namespace being blank / ""
+func TestNamespaceGenerationBlank(t *testing.T) {
+	ns := ""
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": newServiceConfig()},
+		Namespace:      ns,
+	}
+	k := Kubernetes{}
+	objs, err := k.Transform(komposeObject, kobject.ConvertOptions{})
+	if err != nil {
+		t.Error(errors.Wrap(err, "k.Transform failed"))
+	}
+	for _, obj := range objs {
+		if namespace, ok := obj.(*api.Namespace); ok {
+			if strings.ToLower(ns) != strings.ToLower(namespace.ObjectMeta.Name) {
+				t.Errorf("Expected namespace name %v, got %v", ns, namespace.ObjectMeta.Name)
+			}
+		}
+		if dep, ok := obj.(*appsv1.Deployment); ok {
+			if dep.ObjectMeta.Namespace != ns {
+				t.Errorf("Expected deployment namespace %v, got %v", ns, dep.ObjectMeta.Namespace)
+			}
+		}
+	}
+}


### PR DESCRIPTION
only add namespace if specified

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What this PR does / why we need it:

When we generate the YAML, we should NOT add namespace by default,
namespace should only be added if it has been specified via the command
line.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/kompose/issues/1729

#### Special notes for your reviewer:

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
