### PR TITLE
remove status field from generated yaml

### DIFF
--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -275,6 +275,9 @@ func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 // Print either prints to stdout or to file/s
 func Print(name, path string, trailing string, data []byte, toStdout, generateJSON bool, f *os.File, provider string) (string, error) {
 	file := ""
+	// simple hack to remove status from the output
+	re := regexp.MustCompile(`(?s)status:.*`)
+	data = re.ReplaceAll(data, nil)
 	if generateJSON {
 		file = fmt.Sprintf("%s-%s.json", name, trailing)
 	} else {
@@ -292,11 +295,6 @@ func Print(name, path string, trailing string, data []byte, toStdout, generateJS
 	} else {
 		// Write content separately to each file
 		file = filepath.Join(path, file)
-
-		// simple hack to remove status from the output
-		re := regexp.MustCompile(`(?s)status:.*`)
-		data = re.ReplaceAll(data, nil)
-
 		if err := os.WriteFile(file, data, 0644); err != nil {
 			return "", errors.Wrap(err, "Failed to write %s: "+trailing)
 		}

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	dockerlib "github.com/fsouza/go-dockerclient"
@@ -291,6 +292,11 @@ func Print(name, path string, trailing string, data []byte, toStdout, generateJS
 	} else {
 		// Write content separately to each file
 		file = filepath.Join(path, file)
+
+		// simple hack to remove status from the output
+		re := regexp.MustCompile(`status:[\s\S]*?(?:---|$)`)
+		data = re.ReplaceAll(data, nil)
+
 		if err := os.WriteFile(file, data, 0644); err != nil {
 			return "", errors.Wrap(err, "Failed to write %s: "+trailing)
 		}

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -294,7 +294,7 @@ func Print(name, path string, trailing string, data []byte, toStdout, generateJS
 		file = filepath.Join(path, file)
 
 		// simple hack to remove status from the output
-		re := regexp.MustCompile(`status:[\s\S]*?(?:---|$)`)
+		re := regexp.MustCompile(`(?s)status:.*`)
 		data = re.ReplaceAll(data, nil)
 
 		if err := os.WriteFile(file, data, 0644); err != nil {

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -17,8 +17,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: v1
@@ -36,8 +34,6 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: apps/v1
@@ -70,7 +66,6 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-status: {}
 
 ---
 apiVersion: apps/v1
@@ -113,5 +108,3 @@ spec:
       volumes:
         - emptyDir: {}
           name: code-volume
-status: {}
-

--- a/script/test/fixtures/change-in-volume/output-k8s.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s.yaml
@@ -17,9 +17,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
-
 ---
 apiVersion: v1
 kind: Service
@@ -36,9 +33,6 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -70,8 +64,6 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-status: {}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -113,5 +105,3 @@ spec:
       volumes:
         - emptyDir: {}
           name: code-volume
-status: {}
-

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -29,8 +29,6 @@ spec:
           name: foo
           resources: {}
       restartPolicy: Always
-status: {}
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/script/test/fixtures/compose-file-support/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-support/output-k8s.yaml
@@ -14,9 +14,6 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -48,5 +45,3 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
-

--- a/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
@@ -41,8 +41,6 @@ spec:
                 path: configs.tar
             name: db-cm0
           name: db-cm0
-status: {}
-
 ---
 apiVersion: v1
 binaryData:
@@ -105,8 +103,6 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-status: {}
-
 ---
 apiVersion: v1
 data:

--- a/script/test/fixtures/configmap-volume/output-k8s.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s.yaml
@@ -37,7 +37,6 @@ spec:
                 path: configs.tar
             name: db-cm0
           name: db-cm0
-status: {}
 
 ---
 apiVersion: v1
@@ -97,8 +96,6 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-status: {}
-
 ---
 apiVersion: v1
 data:

--- a/script/test/fixtures/custom-build-push/output-k8s.yaml
+++ b/script/test/fixtures/custom-build-push/output-k8s.yaml
@@ -24,8 +24,6 @@ spec:
           name: nginx
           resources: {}
       restartPolicy: Always
-status: {}
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
@@ -14,9 +14,6 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -77,5 +74,3 @@ spec:
           maxSkew: 1
           topologyKey: ssd
           whenUnsatisfiable: ScheduleAnyway
-status: {}
-

--- a/script/test/fixtures/env/output-k8s.yaml
+++ b/script/test/fixtures/env/output-k8s.yaml
@@ -4,9 +4,26 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    io.kompose.service: another-namenode
+  name: another-namenode
+spec:
+  ports:
+    - name: "50070"
+      port: 50070
+      targetPort: 50070
+    - name: "8020"
+      port: 8020
+      targetPort: 8020
+  selector:
+    io.kompose.service: another-namenode
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
     io.kompose.service: namenode
   name: namenode
-  namespace: default
 spec:
   ports:
     - name: "50070"
@@ -17,9 +34,6 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: namenode
-status:
-  loadBalancer: {}
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -28,7 +42,6 @@ metadata:
   labels:
     io.kompose.service: another-namenode
   name: another-namenode
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -56,10 +69,15 @@ spec:
                   name: home-runner-work-kompose-kompose-script-test-fixtures-env-hadoop-hive-namenode-env
           image: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8
           name: another-namenode
+          ports:
+            - containerPort: 50070
+              hostPort: 50070
+              protocol: TCP
+            - containerPort: 8020
+              hostPort: 8020
+              protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
-
 ---
 apiVersion: v1
 data:
@@ -71,8 +89,6 @@ metadata:
   labels:
     io.kompose.service: another-namenode-home-runner-work-kompose-kompose-script-test-fixtures-env-hadoop-hive-namenode-env
   name: home-runner-work-kompose-kompose-script-test-fixtures-env-hadoop-hive-namenode-env
-  namespace: default
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -81,7 +97,6 @@ metadata:
   labels:
     io.kompose.service: namenode
   name: namenode
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -120,5 +135,3 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
-

--- a/script/test/fixtures/envvars-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-k8s.yaml
@@ -33,5 +33,5 @@ spec:
           name: myservice
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -37,8 +36,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -70,7 +68,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -111,7 +109,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -154,6 +152,5 @@ spec:
         - batman.example.com
         - batwoman.example.com
       secretName: test-secret
-status:
-  loadBalancer: {}
+
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
@@ -21,8 +21,7 @@ spec:
   selector:
     io.kompose.service: front-end
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -68,5 +67,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
@@ -21,8 +21,7 @@ spec:
   selector:
     io.kompose.service: front-end
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -68,7 +67,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -97,6 +96,5 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-status:
-  loadBalancer: {}
+
 

--- a/script/test/fixtures/fsgroup/output-k8s.yaml
+++ b/script/test/fixtures/fsgroup/output-k8s.yaml
@@ -43,7 +43,7 @@ spec:
         - name: pgadmin-data
           persistentVolumeClaim:
             claimName: pgadmin-data
-status: {}
+
 
 ---
 apiVersion: v1
@@ -59,7 +59,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
@@ -21,8 +21,7 @@ spec:
       targetPort: 27017
   selector:
     io.kompose.service: my-group
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -47,8 +46,7 @@ spec:
       targetPort: 3306
   selector:
     io.kompose.service: my-group
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -74,8 +72,7 @@ spec:
       targetPort: 5432
   selector:
     io.kompose.service: postgresql
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -98,8 +95,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -175,7 +171,7 @@ spec:
             timeoutSeconds: 2
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -237,7 +233,7 @@ spec:
             timeoutSeconds: 1
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -294,5 +290,5 @@ spec:
             timeoutSeconds: 1
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/host-port-protocol/output-k8s.yaml
+++ b/script/test/fixtures/host-port-protocol/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: nginx
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -48,5 +47,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/multiple-files/output-k8s.yaml
+++ b/script/test/fixtures/multiple-files/output-k8s.yaml
@@ -25,7 +25,7 @@ spec:
           name: bar
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -54,5 +54,5 @@ spec:
           name: foo
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
@@ -37,7 +37,7 @@ spec:
         - name: db-data
           persistentVolumeClaim:
             claimName: db-data
-status: {}
+
 
 ---
 apiVersion: v1
@@ -54,7 +54,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -104,7 +104,7 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-status: {}
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/namespace/output-k8s.yaml
+++ b/script/test/fixtures/namespace/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -25,7 +24,7 @@ metadata:
   name: web
   namespace: web
 spec: {}
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -58,5 +57,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/network-policies/output-k8s.yaml
+++ b/script/test/fixtures/network-policies/output-k8s.yaml
@@ -24,7 +24,7 @@ spec:
           name: nginx
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/script/test/fixtures/read-only/output-k8s.yaml
+++ b/script/test/fixtures/read-only/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: test
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -50,5 +49,5 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/service-group/output-k8s.yaml
+++ b/script/test/fixtures/service-group/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 8000
   selector:
     io.kompose.service: dispatcher-librenms
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -67,7 +66,7 @@ spec:
         - name: dispatcher-librenms-claim0
           persistentVolumeClaim:
             claimName: dispatcher-librenms-claim0
-status: {}
+
 
 ---
 apiVersion: v1
@@ -84,5 +83,5 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -17,8 +17,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: front-end
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -60,7 +59,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -87,6 +86,5 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-status:
-  loadBalancer: {}
+
 

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -16,8 +16,7 @@ spec:
   selector:
     io.kompose.service: db
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -37,8 +36,7 @@ spec:
   selector:
     io.kompose.service: wordpress
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -96,10 +94,6 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      status: {}
-status:
-  availableReplicas: 0
-  replicas: 0
 
 ---
 apiVersion: apps/v1
@@ -157,8 +151,4 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      status: {}
-status:
-  availableReplicas: 0
-  replicas: 0
 

--- a/script/test/fixtures/v2/output-k8s.yaml
+++ b/script/test/fixtures/v2/output-k8s.yaml
@@ -86,8 +86,7 @@ spec:
       targetPort: 5010
   selector:
     io.kompose.service: foo
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -107,8 +106,7 @@ spec:
   selector:
     io.kompose.service: redis
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -129,8 +127,7 @@ spec:
   selector:
     io.kompose.service: redis
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -232,7 +229,7 @@ spec:
   securityContext:
     supplementalGroups:
       - 1234
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -288,5 +285,5 @@ spec:
             limits:
               memory: "10485760e3"
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/v3.0/output-k8s.yaml
+++ b/script/test/fixtures/v3.0/output-k8s.yaml
@@ -17,8 +17,7 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -53,7 +52,7 @@ spec:
           name: foo
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -93,5 +92,5 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/vols-subpath/output-k8s.yaml
+++ b/script/test/fixtures/vols-subpath/output-k8s.yaml
@@ -44,7 +44,7 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: postgres-data
-status: {}
+
 
 ---
 apiVersion: v1
@@ -60,7 +60,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: db
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -55,7 +54,7 @@ spec:
         - name: db-claim0
           persistentVolumeClaim:
             claimName: db-claim0
-status: {}
+
 
 ---
 apiVersion: v1
@@ -72,5 +71,5 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 


### PR DESCRIPTION
/kind feature
#### What type of PR is this?
Whenever the k8s yamls are generated, since status field is part of APIs, it is being added in the generated yamls, which is fine but should not be there since the objects are not applied yet.

#### What this PR does / why we need it:
This just adds a simple hack to remove the status field from generated yamls

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kompose/issues/975
