### PR TITLE
remove status field from generated yaml 

### DIFF
--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	dockerlib "github.com/fsouza/go-dockerclient"
@@ -274,6 +275,10 @@ func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 // Print either prints to stdout or to file/s
 func Print(name, path string, trailing string, data []byte, toStdout, generateJSON bool, f *os.File, provider string) (string, error) {
 	file := ""
+	// simple hack to remove status from the output
+	re := regexp.MustCompile(`(?s)status:.*`)
+	data = re.ReplaceAll(data, nil)
+
 	if generateJSON {
 		file = fmt.Sprintf("%s-%s.json", name, trailing)
 	} else {

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -275,7 +275,7 @@ func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 // Print either prints to stdout or to file/s
 func Print(name, path string, trailing string, data []byte, toStdout, generateJSON bool, f *os.File, provider string) (string, error) {
 	file := ""
-	// simple hack to remove status from the output
+	// TODO: we should refactor / change this hack in the future once we have a better solution
 	re := regexp.MustCompile(`(?s)status:.*`)
 	data = re.ReplaceAll(data, nil)
 

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -34,8 +33,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -67,7 +65,7 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -109,5 +107,5 @@ spec:
       volumes:
         - emptyDir: {}
           name: code-volume
-status: {}
+
 

--- a/script/test/fixtures/change-in-volume/output-k8s.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -34,8 +33,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -67,7 +65,7 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -109,5 +107,5 @@ spec:
       volumes:
         - emptyDir: {}
           name: code-volume
-status: {}
+
 

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -34,8 +33,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -74,13 +74,7 @@ spec:
           kind: ImageStreamTag
           name: redis:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -103,8 +97,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -157,13 +150,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -186,6 +173,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -34,8 +33,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -74,13 +74,7 @@ spec:
           kind: ImageStreamTag
           name: redis:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -103,8 +97,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -157,13 +150,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -186,6 +173,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -15,8 +15,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: foo
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -53,5 +52,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/compose-file-support/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-support/output-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -46,5 +45,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
@@ -40,7 +40,7 @@ spec:
                 path: configs.tar
             name: db-cm0
           name: db-cm0
-status: {}
+
 
 ---
 apiVersion: v1
@@ -102,7 +102,7 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-status: {}
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/configmap-volume/output-k8s.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s.yaml
@@ -36,7 +36,7 @@ spec:
                 path: configs.tar
             name: db-cm0
           name: db-cm0
-status: {}
+
 
 ---
 apiVersion: v1
@@ -94,7 +94,7 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-status: {}
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
@@ -49,13 +49,7 @@ spec:
           kind: ImageStreamTag
           name: db:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -78,8 +72,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1
@@ -150,13 +143,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -179,8 +166,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/configmap-volume/output-os.yaml
+++ b/script/test/fixtures/configmap-volume/output-os.yaml
@@ -47,13 +47,7 @@ spec:
           kind: ImageStreamTag
           name: db:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -76,8 +70,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1
@@ -146,13 +139,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -175,8 +162,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -75,5 +74,5 @@ spec:
           maxSkew: 1
           topologyKey: ssd
           whenUnsatisfiable: ScheduleAnyway
-status: {}
+
 

--- a/script/test/fixtures/deploy/placement/output-placement-os.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-os.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/deploy/placement/output-placement-os.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-os.yaml
@@ -85,13 +85,7 @@ spec:
           kind: ImageStreamTag
           name: redis:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -114,6 +108,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/env-multiple/output-k8s.yaml
+++ b/script/test/fixtures/env-multiple/output-k8s.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: another-namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -37,8 +36,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -79,7 +77,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: v1
@@ -144,5 +142,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/env-multiple/output-os.yaml
+++ b/script/test/fixtures/env-multiple/output-os.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: another-namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -37,8 +36,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/env-multiple/output-os.yaml
+++ b/script/test/fixtures/env-multiple/output-os.yaml
@@ -110,13 +110,7 @@ spec:
           kind: ImageStreamTag
           name: another-namenode:2.0.0-hadoop2.7.4-java8
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -139,8 +133,7 @@ spec:
       name: 2.0.0-hadoop2.7.4-java8
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -194,13 +187,7 @@ spec:
           kind: ImageStreamTag
           name: namenode:2.0.0-hadoop2.7.4-java8
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -223,6 +210,5 @@ spec:
       name: 2.0.0-hadoop2.7.4-java8
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/env/output-k8s.yaml
+++ b/script/test/fixtures/env/output-k8s.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: another-namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -37,8 +36,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -84,7 +82,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: v1
@@ -144,5 +142,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/env/output-os.yaml
+++ b/script/test/fixtures/env/output-os.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: another-namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -37,8 +36,7 @@ spec:
       targetPort: 8020
   selector:
     io.kompose.service: namenode
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/env/output-os.yaml
+++ b/script/test/fixtures/env/output-os.yaml
@@ -105,13 +105,7 @@ spec:
           kind: ImageStreamTag
           name: another-namenode:2.0.0-hadoop2.7.4-java8
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -134,8 +128,7 @@ spec:
       name: 2.0.0-hadoop2.7.4-java8
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -194,13 +187,7 @@ spec:
           kind: ImageStreamTag
           name: namenode:2.0.0-hadoop2.7.4-java8
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -223,6 +210,5 @@ spec:
       name: 2.0.0-hadoop2.7.4-java8
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/envvars-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-k8s.yaml
@@ -32,5 +32,5 @@ spec:
           name: myservice
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/envvars-interpolation/output-os.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-os.yaml
@@ -43,13 +43,7 @@ spec:
           kind: ImageStreamTag
           name: myservice:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -72,6 +66,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -35,8 +34,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -67,7 +65,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -107,7 +105,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -149,6 +147,5 @@ spec:
         - batman.example.com
         - batwoman.example.com
       secretName: test-secret
-status:
-  loadBalancer: {}
+
 

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -35,8 +34,7 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -76,13 +76,7 @@ spec:
           kind: ImageStreamTag
           name: redis:3.0
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -105,8 +99,7 @@ spec:
       name: "3.0"
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -153,13 +146,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -182,8 +169,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1
@@ -201,6 +187,4 @@ spec:
     kind: Service
     name: web
     weight: null
-status:
-  ingress: null
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
@@ -20,8 +20,7 @@ spec:
   selector:
     io.kompose.service: front-end
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -66,5 +65,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
@@ -20,8 +20,7 @@ spec:
   selector:
     io.kompose.service: front-end
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -66,7 +65,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -94,6 +93,5 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-status:
-  loadBalancer: {}
+
 

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -20,8 +20,7 @@ spec:
   selector:
     io.kompose.service: front-end
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -71,13 +71,7 @@ spec:
           kind: ImageStreamTag
           name: front-end:v4
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -100,6 +94,5 @@ spec:
       name: v4
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -20,8 +20,7 @@ spec:
   selector:
     io.kompose.service: front-end
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -71,13 +71,7 @@ spec:
           kind: ImageStreamTag
           name: front-end:v4
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -100,8 +94,7 @@ spec:
       name: v4
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1
@@ -119,6 +112,4 @@ spec:
     kind: Service
     name: front-end
     weight: null
-status:
-  ingress: null
 

--- a/script/test/fixtures/fsgroup/output-k8s.yaml
+++ b/script/test/fixtures/fsgroup/output-k8s.yaml
@@ -43,7 +43,7 @@ spec:
         - name: pgadmin-data
           persistentVolumeClaim:
             claimName: pgadmin-data
-status: {}
+
 
 ---
 apiVersion: v1
@@ -59,4 +59,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+

--- a/script/test/fixtures/fsgroup/output-os.yaml
+++ b/script/test/fixtures/fsgroup/output-os.yaml
@@ -98,4 +98,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+

--- a/script/test/fixtures/fsgroup/output-os.yaml
+++ b/script/test/fixtures/fsgroup/output-os.yaml
@@ -52,13 +52,7 @@ spec:
           kind: ImageStreamTag
           name: pgadmin:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -81,8 +75,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
@@ -20,8 +20,7 @@ spec:
       targetPort: 27017
   selector:
     io.kompose.service: mongo
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -45,8 +44,7 @@ spec:
       targetPort: 3306
   selector:
     io.kompose.service: mysql
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -71,8 +69,7 @@ spec:
       targetPort: 5432
   selector:
     io.kompose.service: postgresql
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -94,8 +91,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -152,7 +148,7 @@ spec:
             timeoutSeconds: 1
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -209,7 +205,7 @@ spec:
             timeoutSeconds: 2
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -270,7 +266,7 @@ spec:
             timeoutSeconds: 1
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -326,5 +322,5 @@ spec:
             timeoutSeconds: 1
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -20,8 +20,7 @@ spec:
       targetPort: 27017
   selector:
     io.kompose.service: mongo
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -45,8 +44,7 @@ spec:
       targetPort: 3306
   selector:
     io.kompose.service: mysql
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -71,8 +69,7 @@ spec:
       targetPort: 5432
   selector:
     io.kompose.service: postgresql
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -94,8 +91,7 @@ spec:
       targetPort: 6379
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -152,13 +152,7 @@ spec:
           kind: ImageStreamTag
           name: mongo:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -181,8 +175,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -243,13 +236,7 @@ spec:
           kind: ImageStreamTag
           name: mysql:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -272,8 +259,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -337,13 +323,7 @@ spec:
           kind: ImageStreamTag
           name: postgresql:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -366,8 +346,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -429,13 +408,7 @@ spec:
           kind: ImageStreamTag
           name: redis:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -458,6 +431,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/host-port-protocol/output-k8s.yaml
+++ b/script/test/fixtures/host-port-protocol/output-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: nginx
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -46,5 +45,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/host-port-protocol/output-os.yaml
+++ b/script/test/fixtures/host-port-protocol/output-os.yaml
@@ -56,13 +56,7 @@ spec:
           kind: ImageStreamTag
           name: nginx:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -85,6 +79,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/host-port-protocol/output-os.yaml
+++ b/script/test/fixtures/host-port-protocol/output-os.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: nginx
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/multiple-files/output-k8s.yaml
+++ b/script/test/fixtures/multiple-files/output-k8s.yaml
@@ -24,7 +24,7 @@ spec:
           name: bar
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -52,5 +52,5 @@ spec:
           name: foo
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/multiple-files/output-os.yaml
+++ b/script/test/fixtures/multiple-files/output-os.yaml
@@ -35,13 +35,7 @@ spec:
           kind: ImageStreamTag
           name: bar:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -64,8 +58,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -104,13 +97,7 @@ spec:
           kind: ImageStreamTag
           name: foo:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -133,6 +120,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
@@ -36,7 +36,7 @@ spec:
         - name: db-data
           persistentVolumeClaim:
             claimName: db-data
-status: {}
+
 
 ---
 apiVersion: v1
@@ -52,7 +52,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -101,7 +101,7 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-status: {}
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/multiple-type-volumes/output-os.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-os.yaml
@@ -45,13 +45,7 @@ spec:
           kind: ImageStreamTag
           name: db:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -74,8 +68,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1
@@ -149,13 +142,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -178,8 +165,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/multiple-type-volumes/output-os.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-os.yaml
@@ -91,7 +91,7 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/namespace/output-k8s.yaml
+++ b/script/test/fixtures/namespace/output-k8s.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -25,7 +24,7 @@ metadata:
   name: web
   namespace: web
 spec: {}
-status: {}
+
 
 ---
 apiVersion: apps/v1
@@ -58,5 +57,5 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/namespace/output-os.yaml
+++ b/script/test/fixtures/namespace/output-os.yaml
@@ -68,13 +68,7 @@ spec:
           kind: ImageStreamTag
           name: web:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -98,6 +92,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/namespace/output-os.yaml
+++ b/script/test/fixtures/namespace/output-os.yaml
@@ -14,8 +14,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: web
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -25,7 +24,7 @@ metadata:
   name: web
   namespace: web
 spec: {}
-status: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/network-policies/output-k8s.yaml
+++ b/script/test/fixtures/network-policies/output-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: nginx
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -46,7 +45,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/script/test/fixtures/read-only/output-k8s.yaml
+++ b/script/test/fixtures/read-only/output-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: test
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -48,5 +47,5 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
       restartPolicy: Always
-status: {}
+
 

--- a/script/test/fixtures/read-only/output-os.yaml
+++ b/script/test/fixtures/read-only/output-os.yaml
@@ -58,13 +58,7 @@ spec:
           kind: ImageStreamTag
           name: test:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -87,6 +81,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/read-only/output-os.yaml
+++ b/script/test/fixtures/read-only/output-os.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: test
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/service-group/output-k8s.yaml
+++ b/script/test/fixtures/service-group/output-k8s.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 8000
   selector:
     io.kompose.service: librenms-dispatcher
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -65,7 +64,7 @@ spec:
         - name: librenms-dispatcher-claim0
           persistentVolumeClaim:
             claimName: librenms-dispatcher-claim0
-status: {}
+
 
 ---
 apiVersion: v1
@@ -81,5 +80,5 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: front-end
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -58,7 +57,7 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-status: {}
+
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -84,6 +83,5 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-status:
-  loadBalancer: {}
+
 

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -91,10 +91,6 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      
-status:
-  availableReplicas: 0
-  replicas: 0
 
 ---
 apiVersion: apps/v1
@@ -151,8 +147,4 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      
-status:
-  availableReplicas: 0
-  replicas: 0
 

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -15,8 +15,7 @@ spec:
   selector:
     io.kompose.service: db
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -35,8 +34,7 @@ spec:
   selector:
     io.kompose.service: wordpress
   type: ClusterIP
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -93,7 +91,7 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      status: {}
+      
 status:
   availableReplicas: 0
   replicas: 0
@@ -153,7 +151,7 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      status: {}
+      
 status:
   availableReplicas: 0
   replicas: 0

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -87,10 +87,6 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      
-status:
-  availableReplicas: 0
-  replicas: 0
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -146,13 +142,7 @@ spec:
           kind: ImageStreamTag
           name: db:5.7
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -175,8 +165,7 @@ spec:
       name: "5.7"
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps/v1
@@ -233,10 +222,6 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      
-status:
-  availableReplicas: 0
-  replicas: 0
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -292,13 +277,7 @@ spec:
           kind: ImageStreamTag
           name: wordpress:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -321,6 +300,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 3306
   selector:
     io.kompose.service: db
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -31,8 +30,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: wordpress
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps/v1
@@ -89,7 +87,7 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      status: {}
+      
 status:
   availableReplicas: 0
   replicas: 0
@@ -235,7 +233,7 @@ spec:
         resources:
           requests:
             storage: 100Mi
-      status: {}
+      
 status:
   availableReplicas: 0
   replicas: 0

--- a/script/test/fixtures/v2/output-k8s.yaml
+++ b/script/test/fixtures/v2/output-k8s.yaml
@@ -86,8 +86,6 @@ spec:
       targetPort: 5010
   selector:
     io.kompose.service: foo
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: v1
@@ -107,8 +105,6 @@ spec:
   selector:
     io.kompose.service: redis
   type: LoadBalancer
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: v1
@@ -129,8 +125,6 @@ spec:
   selector:
     io.kompose.service: redis
   type: LoadBalancer
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: v1
@@ -232,7 +226,6 @@ spec:
   securityContext:
     supplementalGroups:
       - 1234
-status: {}
 
 ---
 apiVersion: apps/v1
@@ -272,5 +265,4 @@ spec:
             limits:
               memory: "10485760e3"
       restartPolicy: Always
-status: {}
 

--- a/script/test/fixtures/v2/output-os.yaml
+++ b/script/test/fixtures/v2/output-os.yaml
@@ -86,8 +86,7 @@ spec:
       targetPort: 5010
   selector:
     io.kompose.service: foo
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -107,8 +106,7 @@ spec:
   selector:
     io.kompose.service: redis
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -129,8 +127,7 @@ spec:
   selector:
     io.kompose.service: redis
   type: LoadBalancer
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: v1
@@ -232,7 +229,7 @@ spec:
   securityContext:
     supplementalGroups:
       - 1234
-status: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/v2/output-os.yaml
+++ b/script/test/fixtures/v2/output-os.yaml
@@ -278,13 +278,7 @@ spec:
           kind: ImageStreamTag
           name: redis:3.0
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -307,6 +301,5 @@ spec:
       name: "3.0"
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/v3.0/output-k8s.yaml
+++ b/script/test/fixtures/v3.0/output-k8s.yaml
@@ -16,8 +16,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: apps/v1
@@ -51,7 +49,6 @@ spec:
           name: foo
           resources: {}
       restartPolicy: Always
-status: {}
 
 ---
 apiVersion: apps/v1
@@ -90,5 +87,4 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-status: {}
 

--- a/script/test/fixtures/v3.0/output-os.yaml
+++ b/script/test/fixtures/v3.0/output-os.yaml
@@ -16,8 +16,7 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1

--- a/script/test/fixtures/v3.0/output-os.yaml
+++ b/script/test/fixtures/v3.0/output-os.yaml
@@ -61,13 +61,7 @@ spec:
           kind: ImageStreamTag
           name: foo:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -90,8 +84,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -139,13 +132,7 @@ spec:
           kind: ImageStreamTag
           name: redis:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -168,6 +155,5 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 

--- a/script/test/fixtures/vols-subpath/output-k8s.yaml
+++ b/script/test/fixtures/vols-subpath/output-k8s.yaml
@@ -44,7 +44,7 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: postgres-data
-status: {}
+
 
 ---
 apiVersion: v1
@@ -60,4 +60,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+

--- a/script/test/fixtures/vols-subpath/output-os.yaml
+++ b/script/test/fixtures/vols-subpath/output-os.yaml
@@ -99,5 +99,5 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 

--- a/script/test/fixtures/vols-subpath/output-os.yaml
+++ b/script/test/fixtures/vols-subpath/output-os.yaml
@@ -53,13 +53,7 @@ spec:
           kind: ImageStreamTag
           name: postgres:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -82,8 +76,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
@@ -13,8 +13,6 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: db
-status:
-  loadBalancer: {}
 
 ---
 apiVersion: apps/v1
@@ -53,7 +51,6 @@ spec:
         - name: db-claim0
           persistentVolumeClaim:
             claimName: db-claim0
-status: {}
 
 ---
 apiVersion: v1
@@ -69,5 +66,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
 

--- a/script/test/fixtures/volume-mounts/windows/output-os.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-os.yaml
@@ -63,13 +63,7 @@ spec:
           kind: ImageStreamTag
           name: db:latest
       type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+
 
 ---
 apiVersion: image.openshift.io/v1
@@ -92,8 +86,7 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-status:
-  dockerImageRepository: ""
+
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/volume-mounts/windows/output-os.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-os.yaml
@@ -13,8 +13,7 @@ spec:
       targetPort: 80
   selector:
     io.kompose.service: db
-status:
-  loadBalancer: {}
+
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -110,5 +109,5 @@ spec:
   resources:
     requests:
       storage: 100Mi
-status: {}
+
 


### PR DESCRIPTION
/kind feature
#### What type of PR is this?
Whenever the k8s yamls are generated, since status field is part of APIs, it is being added in the generated yamls, which is fine but should not be there since the objects are not applied yet.

#### What this PR does / why we need it:
This just adds a simple hack to remove the status field from generated yamls

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/kompose/issues/975
