### PR TITLE
chore: add warning when no service is selected

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -171,6 +171,14 @@ func (c *Compose) LoadFile(files []string, profiles []string) (kobject.KomposeOb
 		return kobject.KomposeObject{}, errors.Wrap(err, "Unable to load files")
 	}
 
+	// Finding 0 services means two things:
+	// 1. The compose project is empty
+	// 2. The profile that is configured in the compose project is different than the one defined in Kompose convert options
+	// In both cases we should provide the user with a warning indicating that we didn't find any service.
+	if len(project.Services) == 0 {
+		log.Warning("No service selected. The profile specified in services of your compose yaml may not exist.")
+	}
+
 	komposeObject, err := dockerComposeToKomposeMapping(project)
 	if err != nil {
 		return kobject.KomposeObject{}, err

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -305,3 +305,8 @@ convert::expect_success "$os_cmd" "$os_output" || exit 1
 # os_output="$KOMPOSE_ROOT/script/test/fixtures/env-multiple/output-os.yaml"
 # convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1
 # convert::expect_success "$os_cmd" "$os_output" || exit 1
+
+# Test that if we have no profile a warning should raised
+cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/no-profile-warning/docker-compose.yaml convert"
+convert::expect_warning "$cmd" "No service selected. The profile specified in services of your compose yaml may not exist." || exit 1
+

--- a/script/test/fixtures/no-profile-warning/docker-compose.yaml
+++ b/script/test/fixtures/no-profile-warning/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  web:
+    image: nginx
+    profiles:
+      - test
+    ports:
+      - 80:80


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What this PR does / why we need it:
This PR adds a warning when no service is selected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1748.

#### Special notes for your reviewer:
