### PR TITLE
feat: Add `COMPOSE_FILE` env variable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -66,6 +66,11 @@ redis-master-deployment.yaml
 
 When multiple docker-compose files are provided the configuration is merged. Any configuration that is common will be over ridden by subsequent file.
 
+You can provide your docker-compose files via environment variables as following:
+```sh
+$ COMPOSE_FILE="docker-compose.yaml alternative-docker-compose.yaml" kompose convert
+```
+
 ### OpenShift
 
 ```sh

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -311,6 +311,7 @@ cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/no-profile-warning/docker-com
 convert::expect_warning "$cmd" "No service selected. The profile specified in services of your compose yaml may not exist." || exit 1
 
 # Test COMPOSE_FILE env variable is honored
-k8s_cmd="COMPOSE_FILE=\"$KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/docker-compose.yaml $KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/alternative-docker-compose.yaml\" kompose convert --stdout --with-kompose-annotation=false"
-k8s_output="$KOMPOSE_ROOT/script/test/fixtures/fixtures/compose-file-env-variable/output-k8s.yaml"
+export COMPOSE_FILE="$KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/docker-compose.yaml $KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/alternative-docker-compose.yaml"
+k8s_cmd="kompose convert --stdout --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/output-k8s.yaml"
 convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -310,3 +310,7 @@ convert::expect_success "$os_cmd" "$os_output" || exit 1
 cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/no-profile-warning/docker-compose.yaml convert"
 convert::expect_warning "$cmd" "No service selected. The profile specified in services of your compose yaml may not exist." || exit 1
 
+# Test COMPOSE_FILE env variable is honored
+k8s_cmd="COMPOSE_FILE=\"$KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/docker-compose.yaml $KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/alternative-docker-compose.yaml\" kompose convert --stdout --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/fixtures/compose-file-env-variable/output-k8s.yaml"
+convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1

--- a/script/test/fixtures/compose-file-env-variable/alternative-docker-compose.yaml
+++ b/script/test/fixtures/compose-file-env-variable/alternative-docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  alpine:
+    image: alpine
+    ports:
+      - 80:80
+

--- a/script/test/fixtures/compose-file-env-variable/docker-compose.yaml
+++ b/script/test/fixtures/compose-file-env-variable/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  debian:
+    image: debian
+    ports:
+      - 80:80

--- a/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: alpine
+  name: alpine
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: alpine
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: debian
+  name: debian
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: debian
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: alpine
+  name: alpine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: alpine
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/compose-file-env-variable-default: "true"
+        io.kompose.service: alpine
+    spec:
+      containers:
+        - image: alpine
+          name: alpine
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: debian
+  name: debian
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: debian
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/compose-file-env-variable-default: "true"
+        io.kompose.service: debian
+    spec:
+      containers:
+        - image: debian
+          name: debian
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What this PR does / why we need it:
This PR aims to add `COMPOSE_FILE` env variable to specify files to convert. e.g.:
```sh
COMPOSE_FILE="docker-compose.yaml alternative-docker-compose.yaml" kompose convert
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1728
