### PR TITLE
fix: disable annotations when flag `--with-kompose-annotation=false` is specified

### DIFF
--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -248,12 +248,13 @@ func ConfigAllLabels(name string, service *kobject.ServiceConfig) map[string]str
 // ConfigAnnotations configures annotations
 func ConfigAnnotations(service kobject.ServiceConfig) map[string]string {
 	annotations := map[string]string{}
-	for key, value := range service.Annotations {
-		annotations[key] = value
-	}
 
 	if !service.WithKomposeAnnotation {
 		return annotations
+	}
+
+	for key, value := range service.Annotations {
+		annotations[key] = value
 	}
 
 	annotations["kompose.cmd"] = strings.Join(os.Args, " ")

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -16,7 +14,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-
 
 ---
 apiVersion: v1
@@ -34,13 +31,10 @@ spec:
   selector:
     io.kompose.service: web
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -53,8 +47,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.type: headless
       creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
@@ -65,7 +57,6 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-
 
 ---
 apiVersion: apps/v1
@@ -107,5 +98,4 @@ spec:
       volumes:
         - emptyDir: {}
           name: code-volume
-
 

--- a/script/test/fixtures/change-in-volume/output-k8s.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -16,7 +14,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-
 
 ---
 apiVersion: v1
@@ -34,13 +31,10 @@ spec:
   selector:
     io.kompose.service: web
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -53,8 +47,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.type: headless
       creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
@@ -65,7 +57,6 @@ spec:
           name: redis
           resources: {}
       restartPolicy: Always
-
 
 ---
 apiVersion: apps/v1
@@ -107,5 +98,4 @@ spec:
       volumes:
         - emptyDir: {}
           name: code-volume
-
 

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -16,7 +14,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-
 
 ---
 apiVersion: v1
@@ -34,13 +31,10 @@ spec:
   selector:
     io.kompose.service: web
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -75,7 +69,6 @@ spec:
           name: redis:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -97,7 +90,6 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -151,7 +143,6 @@ spec:
           name: web:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -173,5 +164,4 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -16,7 +14,6 @@ spec:
       targetPort: 0
   selector:
     io.kompose.service: redis
-
 
 ---
 apiVersion: v1
@@ -34,13 +31,10 @@ spec:
   selector:
     io.kompose.service: web
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -75,7 +69,6 @@ spec:
           name: redis:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -97,7 +90,6 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -151,7 +143,6 @@ spec:
           name: web:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -173,5 +164,4 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.image-pull-policy: IfNotPresent
   creationTimestamp: null
   labels:
     io.kompose.service: foo
@@ -16,13 +14,10 @@ spec:
   selector:
     io.kompose.service: foo
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.image-pull-policy: IfNotPresent
   creationTimestamp: null
   labels:
     io.kompose.service: foo
@@ -35,8 +30,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.image-pull-policy: IfNotPresent
       creationTimestamp: null
       labels:
         io.kompose.network/compose-env-interpolation-default: "true"
@@ -52,5 +45,4 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-
 

--- a/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.volume.type: configMap
   creationTimestamp: null
   labels:
     io.kompose.service: db
@@ -17,8 +15,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.volume.type: configMap
       creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
@@ -41,7 +37,6 @@ spec:
             name: db-cm0
           name: db-cm0
 
-
 ---
 apiVersion: v1
 binaryData:
@@ -59,8 +54,6 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.volume.type: configMap
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -74,8 +67,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.volume.type: configMap
       creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
@@ -102,7 +93,6 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.volume.type: configMap
   creationTimestamp: null
   labels:
     io.kompose.service: db
@@ -50,7 +48,6 @@ spec:
           name: db:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -73,7 +70,6 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: v1
 binaryData:
@@ -91,8 +87,6 @@ metadata:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.volume.type: configMap
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -144,7 +138,6 @@ spec:
           name: web:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -166,7 +159,6 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -14,15 +14,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: batman.example.com/dev,batwoman.example.com
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.expose.tls-secret: test-secret
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -34,7 +29,6 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-
 
 ---
 apiVersion: apps/v1
@@ -66,15 +60,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.expose: batman.example.com/dev,batwoman.example.com
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.expose.tls-secret: test-secret
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -87,10 +76,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.expose: batman.example.com/dev,batwoman.example.com
-        kompose.service.expose.ingress-class-name: nginx
-        kompose.service.expose.tls-secret: test-secret
       creationTimestamp: null
       labels:
         io.kompose.network/expose-default: "true"
@@ -106,15 +91,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kompose.service.expose: batman.example.com/dev,batwoman.example.com
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.expose.tls-secret: test-secret
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -147,5 +127,4 @@ spec:
         - batman.example.com
         - batwoman.example.com
       secretName: test-secret
-
 

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -14,15 +14,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: batman.example.com/dev,batwoman.example.com
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.expose.tls-secret: test-secret
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -34,7 +29,6 @@ spec:
       targetPort: 5000
   selector:
     io.kompose.service: web
-
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -77,7 +71,6 @@ spec:
           name: redis:3.0
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -100,15 +93,10 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.expose: batman.example.com/dev,batwoman.example.com
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.expose.tls-secret: test-secret
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -147,7 +135,6 @@ spec:
           name: web:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -169,7 +156,6 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
@@ -2,11 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: loadbalancer
   creationTimestamp: null
   labels:
     io.kompose.service: front-end-tcp
@@ -21,16 +16,10 @@ spec:
     io.kompose.service: front-end
   type: LoadBalancer
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: loadbalancer
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -43,11 +32,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.expose: lb
-        kompose.service.expose.ingress-class-name: nginx
-        kompose.service.external-traffic-policy: local
-        kompose.service.type: loadbalancer
       creationTimestamp: null
       labels:
         io.kompose.network/external-traffic-policy-default: "true"
@@ -65,5 +49,4 @@ spec:
               protocol: TCP
           resources: {}
       restartPolicy: Always
-
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
@@ -2,11 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -21,16 +16,10 @@ spec:
     io.kompose.service: front-end
   type: ClusterIP
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -43,11 +32,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.expose: lb
-        kompose.service.expose.ingress-class-name: nginx
-        kompose.service.external-traffic-policy: local
-        kompose.service.type: headless
       creationTimestamp: null
       labels:
         io.kompose.network/external-traffic-policy-default: "true"
@@ -66,16 +50,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -93,5 +71,4 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-
 

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -2,11 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: loadbalancer
   creationTimestamp: null
   labels:
     io.kompose.service: front-end-tcp
@@ -21,16 +16,10 @@ spec:
     io.kompose.service: front-end
   type: LoadBalancer
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: loadbalancer
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -72,7 +61,6 @@ spec:
           name: front-end:v4
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -94,5 +82,4 @@ spec:
       name: v4
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -2,11 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -21,16 +16,10 @@ spec:
     io.kompose.service: front-end
   type: ClusterIP
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
-    kompose.service.external-traffic-policy: local
-    kompose.service.type: headless
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -72,7 +61,6 @@ spec:
           name: front-end:v4
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -94,7 +82,6 @@ spec:
       name: v4
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/fsgroup/output-k8s.yaml
+++ b/script/test/fixtures/fsgroup/output-k8s.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.security-context.fsgroup: "1001"
   creationTimestamp: null
   labels:
     io.kompose.service: pgadmin
@@ -17,8 +15,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.security-context.fsgroup: "1001"
       creationTimestamp: null
       labels:
         io.kompose.network/fsgroup-default: "true"
@@ -43,7 +39,6 @@ spec:
         - name: pgadmin-data
           persistentVolumeClaim:
             claimName: pgadmin-data
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/fsgroup/output-os.yaml
+++ b/script/test/fixtures/fsgroup/output-os.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.security-context.fsgroup: "1001"
   creationTimestamp: null
   labels:
     io.kompose.service: pgadmin
@@ -53,7 +51,6 @@ spec:
           name: pgadmin:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -75,7 +72,6 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
@@ -2,13 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.tcp_port: "9090"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: mongo
@@ -21,18 +14,10 @@ spec:
   selector:
     io.kompose.service: mongo
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8081"
-    kompose.service.healthcheck.readiness.interval: 11s
-    kompose.service.healthcheck.readiness.retries: "6"
-    kompose.service.healthcheck.readiness.tcp_port: "9091"
-    kompose.service.healthcheck.readiness.timeout: 2s
   creationTimestamp: null
   labels:
     io.kompose.service: mysql
@@ -45,19 +30,10 @@ spec:
   selector:
     io.kompose.service: mysql
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.healthcheck.liveness.http_get_path: /health
-    kompose.service.healthcheck.liveness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.http_get_path: /ready
-    kompose.service.healthcheck.readiness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: postgresql
@@ -70,16 +46,10 @@ spec:
   selector:
     io.kompose.service: postgresql
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.test: echo "liveness"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -92,18 +62,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.tcp_port: "9090"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: mongo
@@ -116,13 +78,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.group: my-group
-        kompose.service.healthcheck.liveness.tcp_port: "8080"
-        kompose.service.healthcheck.readiness.interval: 10s
-        kompose.service.healthcheck.readiness.retries: "5"
-        kompose.service.healthcheck.readiness.tcp_port: "9090"
-        kompose.service.healthcheck.readiness.timeout: 1s
       creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
@@ -149,18 +104,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8081"
-    kompose.service.healthcheck.readiness.interval: 11s
-    kompose.service.healthcheck.readiness.retries: "6"
-    kompose.service.healthcheck.readiness.tcp_port: "9091"
-    kompose.service.healthcheck.readiness.timeout: 2s
   creationTimestamp: null
   labels:
     io.kompose.service: mysql
@@ -173,13 +120,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.group: my-group
-        kompose.service.healthcheck.liveness.tcp_port: "8081"
-        kompose.service.healthcheck.readiness.interval: 11s
-        kompose.service.healthcheck.readiness.retries: "6"
-        kompose.service.healthcheck.readiness.tcp_port: "9091"
-        kompose.service.healthcheck.readiness.timeout: 2s
       creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
@@ -206,19 +146,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.healthcheck.liveness.http_get_path: /health
-    kompose.service.healthcheck.liveness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.http_get_path: /ready
-    kompose.service.healthcheck.readiness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: postgresql
@@ -231,14 +162,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.healthcheck.liveness.http_get_path: /health
-        kompose.service.healthcheck.liveness.http_get_port: "8080"
-        kompose.service.healthcheck.readiness.http_get_path: /ready
-        kompose.service.healthcheck.readiness.http_get_port: "8080"
-        kompose.service.healthcheck.readiness.interval: 10s
-        kompose.service.healthcheck.readiness.retries: "5"
-        kompose.service.healthcheck.readiness.timeout: 1s
       creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
@@ -267,16 +190,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.test: echo "liveness"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -289,11 +206,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.healthcheck.readiness.interval: 10s
-        kompose.service.healthcheck.readiness.retries: "5"
-        kompose.service.healthcheck.readiness.test: echo "liveness"
-        kompose.service.healthcheck.readiness.timeout: 1s
       creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
@@ -322,5 +234,4 @@ spec:
             timeoutSeconds: 1
           resources: {}
       restartPolicy: Always
-
 

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -2,13 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.tcp_port: "9090"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: mongo
@@ -21,18 +14,10 @@ spec:
   selector:
     io.kompose.service: mongo
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8081"
-    kompose.service.healthcheck.readiness.interval: 11s
-    kompose.service.healthcheck.readiness.retries: "6"
-    kompose.service.healthcheck.readiness.tcp_port: "9091"
-    kompose.service.healthcheck.readiness.timeout: 2s
   creationTimestamp: null
   labels:
     io.kompose.service: mysql
@@ -45,19 +30,10 @@ spec:
   selector:
     io.kompose.service: mysql
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.healthcheck.liveness.http_get_path: /health
-    kompose.service.healthcheck.liveness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.http_get_path: /ready
-    kompose.service.healthcheck.readiness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: postgresql
@@ -70,16 +46,10 @@ spec:
   selector:
     io.kompose.service: postgresql
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.test: echo "liveness"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -92,18 +62,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.tcp_port: "9090"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: mongo
@@ -153,7 +115,6 @@ spec:
           name: mongo:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -176,18 +137,10 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.group: my-group
-    kompose.service.healthcheck.liveness.tcp_port: "8081"
-    kompose.service.healthcheck.readiness.interval: 11s
-    kompose.service.healthcheck.readiness.retries: "6"
-    kompose.service.healthcheck.readiness.tcp_port: "9091"
-    kompose.service.healthcheck.readiness.timeout: 2s
   creationTimestamp: null
   labels:
     io.kompose.service: mysql
@@ -237,7 +190,6 @@ spec:
           name: mysql:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -260,19 +212,10 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.healthcheck.liveness.http_get_path: /health
-    kompose.service.healthcheck.liveness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.http_get_path: /ready
-    kompose.service.healthcheck.readiness.http_get_port: "8080"
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: postgresql
@@ -324,7 +267,6 @@ spec:
           name: postgresql:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -347,16 +289,10 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.healthcheck.readiness.interval: 10s
-    kompose.service.healthcheck.readiness.retries: "5"
-    kompose.service.healthcheck.readiness.test: echo "liveness"
-    kompose.service.healthcheck.readiness.timeout: 1s
   creationTimestamp: null
   labels:
     io.kompose.service: redis
@@ -409,7 +345,6 @@ spec:
           name: redis:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -431,5 +366,4 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.volume.type: persistentVolumeClaim
   creationTimestamp: null
   labels:
     io.kompose.service: db
@@ -17,8 +15,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.volume.type: persistentVolumeClaim
       creationTimestamp: null
       labels:
         io.kompose.network/multiple-type-volumes-default: "true"
@@ -37,7 +33,6 @@ spec:
           persistentVolumeClaim:
             claimName: db-data
 
-
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -53,13 +48,10 @@ spec:
     requests:
       storage: 100Mi
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.volume.type: configMap
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -73,8 +65,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.volume.type: configMap
       creationTimestamp: null
       labels:
         io.kompose.network/multiple-type-volumes-default: "true"
@@ -101,7 +91,6 @@ spec:
                 path: test-a-key.key
             name: web-cm1
           name: web-cm1
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/multiple-type-volumes/output-os.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-os.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.volume.type: persistentVolumeClaim
   creationTimestamp: null
   labels:
     io.kompose.service: db
@@ -46,7 +44,6 @@ spec:
           name: db:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -69,7 +66,6 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -85,13 +81,10 @@ spec:
     requests:
       storage: 100Mi
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.volume.type: configMap
   creationTimestamp: null
   labels:
     io.kompose.service: web
@@ -143,7 +136,6 @@ spec:
           name: web:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -165,7 +157,6 @@ spec:
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -2,9 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -17,14 +14,10 @@ spec:
   selector:
     io.kompose.service: front-end
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -37,9 +30,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        kompose.service.expose: lb
-        kompose.service.expose.ingress-class-name: nginx
       creationTimestamp: null
       labels:
         io.kompose.network/single-file-output-default: "true"
@@ -58,14 +48,10 @@ spec:
           resources: {}
       restartPolicy: Always
 
-
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kompose.service.expose: lb
-    kompose.service.expose.ingress-class-name: nginx
   creationTimestamp: null
   labels:
     io.kompose.service: front-end
@@ -83,5 +69,4 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
-
 

--- a/script/test/fixtures/vols-subpath/output-k8s.yaml
+++ b/script/test/fixtures/vols-subpath/output-k8s.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.volume.subpath: test
   creationTimestamp: null
   labels:
     io.kompose.service: postgres
@@ -17,8 +15,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      annotations:
-        kompose.volume.subpath: test
       creationTimestamp: null
       labels:
         io.kompose.network/vols-subpath-default: "true"
@@ -44,7 +40,6 @@ spec:
         - name: postgres-data
           persistentVolumeClaim:
             claimName: postgres-data
-
 
 ---
 apiVersion: v1

--- a/script/test/fixtures/vols-subpath/output-os.yaml
+++ b/script/test/fixtures/vols-subpath/output-os.yaml
@@ -2,8 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.volume.subpath: test
   creationTimestamp: null
   labels:
     io.kompose.service: postgres
@@ -54,7 +52,6 @@ spec:
           name: postgres:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
@@ -77,7 +74,6 @@ spec:
       referencePolicy:
         type: ""
 
-
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -92,5 +88,4 @@ spec:
   resources:
     requests:
       storage: 100Mi
-
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
This PR aims to remove annotations when the `--with-kompose-annotation=false` is specified. Previously, annotations were still present even when --with-kompose-annotation=false was passed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1713.