### PR TITLE
fix: lowercase resources names

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -463,7 +463,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 	for _, composeServiceConfig := range composeObject.Services {
 		// Standard import
 		// No need to modify before importation
-		name := composeServiceConfig.Name
+		name := strings.ToLower(composeServiceConfig.Name)
 		serviceConfig := kobject.ServiceConfig{}
 		serviceConfig.Name = name
 		serviceConfig.Image = composeServiceConfig.Image

--- a/script/test/cmd/tests_new.sh
+++ b/script/test/cmd/tests_new.sh
@@ -315,3 +315,11 @@ export COMPOSE_FILE="$KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variabl
 k8s_cmd="kompose convert --stdout --with-kompose-annotation=false"
 k8s_output="$KOMPOSE_ROOT/script/test/fixtures/compose-file-env-variable/output-k8s.yaml"
 convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1
+
+# Test resources names lowercase
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/resources-lowercase/docker-compose.yaml convert --stdout --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/resources-lowercase/output-k8s.yaml"
+os_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/resources-lowercase/docker-compose.yaml convert --provider openshift --stdout --with-kompose-annotation=false"
+os_output="$KOMPOSE_ROOT/script/test/fixtures/resources-lowercase/output-os.yaml"
+convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1
+convert::expect_success "$os_cmd" "$os_output" || exit 1

--- a/script/test/fixtures/resources-lowercase/docker-compose.yaml
+++ b/script/test/fixtures/resources-lowercase/docker-compose.yaml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  NGINX:
+    image: nginx:latest
+    ports:
+    - 80:80

--- a/script/test/fixtures/resources-lowercase/output-k8s.yaml
+++ b/script/test/fixtures/resources-lowercase/output-k8s.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: nginx
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: nginx
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/resources-lowercase-default: "true"
+        io.kompose.service: nginx
+    spec:
+      containers:
+        - image: nginx:latest
+          name: nginx
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+

--- a/script/test/fixtures/resources-lowercase/output-os.yaml
+++ b/script/test/fixtures/resources-lowercase/output-os.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: nginx
+
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    io.kompose.service: nginx
+  strategy:
+    resources: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/resources-lowercase-default: "true"
+        io.kompose.service: nginx
+    spec:
+      containers:
+        - image: ' '
+          name: nginx
+          ports:
+            - containerPort: 80
+              hostPort: 80
+              protocol: TCP
+          resources: {}
+      restartPolicy: Always
+  test: false
+  triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - nginx
+        from:
+          kind: ImageStreamTag
+          name: nginx:latest
+      type: ImageChange
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - annotations: null
+      from:
+        kind: DockerImage
+        name: nginx:latest
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
This PR aims to fix resource names. Previously, when the Compose service was capitalized, k8s resources names would be capitalized also, which would result in errors when trying to apply them. This PR aims to lowercase k8s resource names to reduce the amount of manual work that should be done by Kompose users.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1702 