### PR TITLE
feat(1765): remove useless keys from the output yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,8 @@ tags
 
 .DS_Store
 
+# VSCode specific
+.vscode
+
 # Client Test generated files
 client/testdata/generated

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -280,6 +280,34 @@ func marshal(obj runtime.Object, jsonFormat bool, indent int) (data []byte, err 
 	return
 }
 
+// remove empty map[string]interface{} strings from the object
+//
+// Note: this function uses recursion, use it only objects created by the unmarshalled json.
+// Passing cyclic structures to removeEmptyInterfaces will result in a stack overflow.
+func removeEmptyInterfaces(obj interface{}) interface{} {
+	switch v := obj.(type) {
+	case []interface{}:
+		for i, val := range v {
+			if valMap, ok := val.(map[string]interface{}); (ok && len(valMap) == 0) || val == nil {
+				v = append(v[:i], v[i+1:]...)
+			} else {
+				v[i] = removeEmptyInterfaces(val)
+			}
+		}
+	case map[string]interface{}:
+		for k, val := range v {
+			if valMap, ok := val.(map[string]interface{}); (ok && len(valMap) == 0) || val == nil {
+				delete(v, k)
+			} else {
+				v[k] = removeEmptyInterfaces(val)
+			}
+		}
+	default:
+		return v
+	}
+	return obj
+}
+
 // Convert JSON to YAML.
 func jsonToYaml(j []byte, spaces int) ([]byte, error) {
 	// Convert the JSON to an object.
@@ -293,7 +321,7 @@ func jsonToYaml(j []byte, spaces int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	jsonObj = removeEmptyInterfaces(jsonObj)
 	var b bytes.Buffer
 	encoder := yaml.NewEncoder(&b)
 	encoder.SetIndent(spaces)

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -294,18 +294,30 @@ func removeEmptyInterfaces(obj interface{}) interface{} {
 				v[i] = removeEmptyInterfaces(val)
 			}
 		}
+		return v
 	case map[string]interface{}:
 		for k, val := range v {
-			if valMap, ok := val.(map[string]interface{}); (ok && len(valMap) == 0) || val == nil {
+			if valMap, ok := val.(map[string]interface{}); ok {
+				// It is always map[string]interface{} when passed the map[string]interface{}
+				valMap := removeEmptyInterfaces(valMap).(map[string]interface{})
+				if len(valMap) == 0 {
+					delete(v, k)
+				}
+			} else if val == nil {
 				delete(v, k)
 			} else {
-				v[k] = removeEmptyInterfaces(val)
+				processedInterface := removeEmptyInterfaces(val)
+				if valSlice, ok := processedInterface.([]interface{}); ok && len(valSlice) == 0 {
+					delete(v, k)
+				} else {
+					v[k] = processedInterface
+				}
 			}
 		}
+		return v
 	default:
 		return v
 	}
-	return obj
 }
 
 // Convert JSON to YAML.

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetes
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -700,6 +701,30 @@ func TestFormatEnvName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := FormatEnvName(tt.args.name); got != tt.want {
 				t.Errorf("FormatEnvName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test empty interfaces removal
+func TestRemoveEmptyInterfaces(t *testing.T) {
+	type Obj = map[string]interface{}
+	var testCases = []struct {
+		input  interface{}
+		output interface{}
+	}{
+		{Obj{"useless": Obj{}}, Obj{}},
+		{Obj{"usefull": Obj{"usefull": "usefull"}}, Obj{"usefull": Obj{"usefull": "usefull"}}},
+		{Obj{"usefull": Obj{"usefull": "usefull", "uselessdeep": Obj{}, "uselessnil": nil}}, Obj{"usefull": Obj{"usefull": "usefull"}}},
+		{Obj{"uselessdeep": Obj{"uselessdeep": Obj{}, "uselessnil": nil}}, Obj{}},
+		{Obj{"uselessempty": []interface{}{nil}}, Obj{}},
+		{"test", "test"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Test removeEmptyInterfaces(%s)", tc.input), func(t *testing.T) {
+			result := removeEmptyInterfaces(tc.input)
+			if !reflect.DeepEqual(result, tc.output) {
+				t.Errorf("Expected %v, got %v", tc.output, result)
 			}
 		})
 	}

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -1145,25 +1145,3 @@ func TestNamespaceGenerationBlank(t *testing.T) {
 		}
 	}
 }
-
-// Test empty interfaces removal
-func TestRemoveEmptyInterfaces(t *testing.T) {
-	type Obj = map[string]interface{}
-	var testCases = []struct {
-		input  interface{}
-		output interface{}
-	}{
-		{Obj{"useless": Obj{}}, Obj{}},
-		{Obj{"usefull": Obj{"usefull": "usefull"}}, Obj{"usefull": Obj{"usefull": "usefull"}}},
-		{Obj{"usefull": Obj{"usefull": "usefull", "uselessdeep": Obj{}, "uselessnil": nil}}, Obj{"usefull": Obj{"usefull": "usefull"}}},
-		{"test", "test"},
-	}
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("Test removeEmptyInterfaces(%s)", tc.input), func(t *testing.T) {
-			result := removeEmptyInterfaces(tc.input)
-			if !reflect.DeepEqual(result, tc.output) {
-				t.Errorf("Expected %v, got %v", tc.output, result)
-			}
-		})
-	}
-}

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -1145,3 +1145,25 @@ func TestNamespaceGenerationBlank(t *testing.T) {
 		}
 	}
 }
+
+// Test empty interfaces removal
+func TestRemoveEmptyInterfaces(t *testing.T) {
+	type Obj = map[string]interface{}
+	var testCases = []struct {
+		input  interface{}
+		output interface{}
+	}{
+		{Obj{"useless": Obj{}}, Obj{}},
+		{Obj{"usefull": Obj{"usefull": "usefull"}}, Obj{"usefull": Obj{"usefull": "usefull"}}},
+		{Obj{"usefull": Obj{"usefull": "usefull", "uselessdeep": Obj{}, "uselessnil": nil}}, Obj{"usefull": Obj{"usefull": "usefull"}}},
+		{"test", "test"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Test removeEmptyInterfaces(%s)", tc.input), func(t *testing.T) {
+			result := removeEmptyInterfaces(tc.input)
+			if !reflect.DeepEqual(result, tc.output) {
+				t.Errorf("Expected %v, got %v", tc.output, result)
+			}
+		})
+	}
+}

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -19,7 +18,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -35,7 +33,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -44,10 +41,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
@@ -55,14 +50,12 @@ spec:
       containers:
         - image: redis
           name: redis
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -75,7 +68,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
@@ -90,12 +82,10 @@ spec:
             - containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /code
               name: code-volume
       restartPolicy: Always
       volumes:
-        - emptyDir: {}
-          name: code-volume
+        - name: code-volume
 

--- a/script/test/fixtures/change-in-volume/output-k8s.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -19,7 +18,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -35,7 +33,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -44,10 +41,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
@@ -55,14 +50,12 @@ spec:
       containers:
         - image: redis
           name: redis
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -75,7 +68,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
@@ -90,12 +82,10 @@ spec:
             - containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /code
               name: code-volume
       restartPolicy: Always
       volumes:
-        - emptyDir: {}
-          name: code-volume
+        - name: code-volume
 

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -19,7 +18,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -35,7 +33,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -43,11 +40,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
@@ -55,7 +49,6 @@ spec:
       containers:
         - image: ' '
           name: redis
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -73,7 +66,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -81,12 +73,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -95,7 +84,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -104,11 +92,9 @@ spec:
   selector:
     io.kompose.service: web
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
@@ -123,14 +109,12 @@ spec:
             - containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /code
               name: code-volume
       restartPolicy: Always
       volumes:
-        - emptyDir: {}
-          name: code-volume
+        - name: code-volume
   test: false
   triggers:
     - type: ConfigChange
@@ -147,7 +131,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -155,12 +138,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: flask_web
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -19,7 +18,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -35,7 +33,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -43,11 +40,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
@@ -55,7 +49,6 @@ spec:
       containers:
         - image: ' '
           name: redis
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -73,7 +66,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -81,12 +73,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -95,7 +84,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -104,11 +92,9 @@ spec:
   selector:
     io.kompose.service: web
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
@@ -123,14 +109,12 @@ spec:
             - containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /code
               name: code-volume
       restartPolicy: Always
       volumes:
-        - emptyDir: {}
-          name: code-volume
+        - name: code-volume
   test: false
   triggers:
     - type: ConfigChange
@@ -147,7 +131,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -155,12 +138,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: flask_web
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -18,7 +17,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -27,10 +25,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: foo
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/compose-env-interpolation-default: "true"
         io.kompose.service: foo
@@ -43,6 +39,5 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 

--- a/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: alpine
   name: alpine
@@ -18,7 +17,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: debian
   name: debian
@@ -34,7 +32,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: alpine
   name: alpine
@@ -43,10 +40,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: alpine
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/compose-file-env-variable-default: "true"
         io.kompose.service: alpine
@@ -58,14 +53,12 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: debian
   name: debian
@@ -74,10 +67,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: debian
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/compose-file-env-variable-default: "true"
         io.kompose.service: debian
@@ -89,6 +80,5 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 

--- a/script/test/fixtures/compose-file-support/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-support/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -19,7 +18,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -28,10 +26,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: web
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/compose-file-support-default: "true"
         io.kompose.service: web
@@ -43,7 +39,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 

--- a/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -15,7 +14,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
@@ -23,7 +21,6 @@ spec:
       containers:
         - image: mysql
           name: db
-          resources: {}
           volumeMounts:
             - mountPath: /data/configs.tar
               name: db-cm0
@@ -45,7 +42,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db-cm0
@@ -54,7 +50,6 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -67,7 +62,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
@@ -75,7 +69,6 @@ spec:
       containers:
         - image: nginx
           name: web
-          resources: {}
           volumeMounts:
             - mountPath: /etc/tls
               name: web-cm0
@@ -101,7 +94,6 @@ data:
   a.key: test-key-data....
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm0
@@ -114,7 +106,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm1

--- a/script/test/fixtures/configmap-volume/output-k8s.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -15,7 +14,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
@@ -23,7 +21,6 @@ spec:
       containers:
         - image: mysql
           name: db
-          resources: {}
           volumeMounts:
             - mountPath: /data/configs.tar
               name: db-cm0
@@ -46,7 +43,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db-cm0
@@ -55,7 +51,6 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -68,7 +63,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
@@ -76,7 +70,6 @@ spec:
       containers:
         - image: nginx
           name: web
-          resources: {}
           volumeMounts:
             - mountPath: /etc/tls
               name: web-cm0
@@ -95,7 +88,6 @@ spec:
             name: web-cm1
           name: web-cm1
 
-
 ---
 apiVersion: v1
 data:
@@ -103,7 +95,6 @@ data:
   a.key: test-key-data....
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm0
@@ -116,7 +107,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm1

--- a/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -11,11 +10,9 @@ spec:
   selector:
     io.kompose.service: db
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
@@ -23,7 +20,6 @@ spec:
       containers:
         - image: ' '
           name: db
-          resources: {}
           volumeMounts:
             - mountPath: /data/configs.tar
               name: db-cm0
@@ -52,7 +48,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -60,12 +55,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: mysql
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -78,7 +70,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db-cm0
@@ -87,7 +78,6 @@ metadata:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -96,11 +86,9 @@ spec:
   selector:
     io.kompose.service: web
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
@@ -108,7 +96,6 @@ spec:
       containers:
         - image: ' '
           name: web
-          resources: {}
           volumeMounts:
             - mountPath: /etc/tls
               name: web-cm0
@@ -142,7 +129,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -150,12 +136,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -167,7 +150,6 @@ data:
   a.key: test-key-data....
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm0
@@ -180,7 +162,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm1

--- a/script/test/fixtures/configmap-volume/output-os.yaml
+++ b/script/test/fixtures/configmap-volume/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -11,11 +10,9 @@ spec:
   selector:
     io.kompose.service: db
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
@@ -23,7 +20,6 @@ spec:
       containers:
         - image: ' '
           name: db
-          resources: {}
           volumeMounts:
             - mountPath: /data/configs.tar
               name: db-cm0
@@ -53,7 +49,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -61,16 +56,12 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: mysql
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1
@@ -80,7 +71,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db-cm0
@@ -89,7 +79,6 @@ metadata:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -98,11 +87,9 @@ spec:
   selector:
     io.kompose.service: web
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
@@ -110,7 +97,6 @@ spec:
       containers:
         - image: ' '
           name: web
-          resources: {}
           volumeMounts:
             - mountPath: /etc/tls
               name: web-cm0
@@ -145,7 +131,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -153,16 +138,12 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: v1
@@ -171,7 +152,6 @@ data:
   a.key: test-key-data....
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm0
@@ -184,7 +164,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm1

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -14,12 +13,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -28,10 +25,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/placement-default: "true"
         io.kompose.service: redis
@@ -59,7 +54,6 @@ spec:
           ports:
             - containerPort: 6379
               protocol: TCP
-          resources: {}
       restartPolicy: Always
       topologySpreadConstraints:
         - labelSelector:

--- a/script/test/fixtures/deploy/placement/output-placement-os.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -14,12 +13,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -27,11 +24,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/placement-default: "true"
         io.kompose.service: redis
@@ -59,7 +53,6 @@ spec:
           ports:
             - containerPort: 6379
               protocol: TCP
-          resources: {}
       restartPolicy: Always
       topologySpreadConstraints:
         - labelSelector:
@@ -86,12 +79,10 @@ spec:
           name: redis:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -99,14 +90,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/env/output-k8s.yaml
+++ b/script/test/fixtures/env/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode
   name: another-namenode
@@ -17,12 +16,10 @@ spec:
   selector:
     io.kompose.service: another-namenode
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: namenode
   name: namenode
@@ -37,12 +34,10 @@ spec:
   selector:
     io.kompose.service: namenode
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode
   name: another-namenode
@@ -51,10 +46,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: another-namenode
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/env-default: "true"
         io.kompose.service: another-namenode
@@ -80,7 +73,6 @@ spec:
             - containerPort: 8020
               hostPort: 8020
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 
@@ -91,7 +83,6 @@ data:
   FOO: BAR
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode-hadoop-hive-namenode-env
   name: hadoop-hive-namenode-env
@@ -100,7 +91,6 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: namenode
   name: namenode
@@ -109,10 +99,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: namenode
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/env-default: "true"
         io.kompose.service: namenode
@@ -140,7 +128,6 @@ spec:
             - containerPort: 8020
               hostPort: 8020
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 

--- a/script/test/fixtures/env/output-os.yaml
+++ b/script/test/fixtures/env/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode
   name: another-namenode
@@ -17,12 +16,10 @@ spec:
   selector:
     io.kompose.service: another-namenode
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: namenode
   name: namenode
@@ -37,7 +34,6 @@ spec:
   selector:
     io.kompose.service: namenode
 
-
 ---
 apiVersion: v1
 data:
@@ -45,7 +41,6 @@ data:
   FOO: BAR
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode-hadoop-hive-namenode-env
   name: hadoop-hive-namenode-env
@@ -54,7 +49,6 @@ metadata:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode
   name: another-namenode
@@ -62,11 +56,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: another-namenode
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/env-default: "true"
         io.kompose.service: another-namenode
@@ -92,7 +83,6 @@ spec:
             - containerPort: 8020
               hostPort: 8020
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -106,12 +96,10 @@ spec:
           name: another-namenode:2.0.0-hadoop2.7.4-java8
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: another-namenode
   name: another-namenode
@@ -119,22 +107,17 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8
-      generation: null
-      importPolicy: {}
       name: 2.0.0-hadoop2.7.4-java8
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: namenode
   name: namenode
@@ -142,11 +125,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: namenode
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/env-default: "true"
         io.kompose.service: namenode
@@ -174,7 +154,6 @@ spec:
             - containerPort: 8020
               hostPort: 8020
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -188,12 +167,10 @@ spec:
           name: namenode:2.0.0-hadoop2.7.4-java8
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: namenode
   name: namenode
@@ -201,14 +178,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8
-      generation: null
-      importPolicy: {}
       name: 2.0.0-hadoop2.7.4-java8
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/envvars-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: myservice
   name: myservice
@@ -11,10 +10,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: myservice
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/envvars-interpolation-default: "true"
         io.kompose.service: myservice
@@ -30,7 +27,6 @@ spec:
               value: https
           image: alpine
           name: myservice
-          resources: {}
       restartPolicy: Always
 
 

--- a/script/test/fixtures/envvars-interpolation/output-os.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: myservice
   name: myservice
@@ -10,11 +9,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: myservice
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/envvars-interpolation-default: "true"
         io.kompose.service: myservice
@@ -30,7 +26,6 @@ spec:
               value: https
           image: ' '
           name: myservice
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -44,12 +39,10 @@ spec:
           name: myservice:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: myservice
   name: myservice
@@ -57,14 +50,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: alpine
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -18,7 +17,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -34,7 +32,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -43,10 +40,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/expose-default: "true"
         io.kompose.service: redis
@@ -57,14 +52,12 @@ spec:
           ports:
             - containerPort: 6379
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -73,10 +66,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: web
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/expose-default: "true"
         io.kompose.service: web
@@ -88,14 +79,12 @@ spec:
             - containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -18,7 +17,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -34,7 +32,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -42,11 +39,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/expose-default: "true"
         io.kompose.service: redis
@@ -57,7 +51,6 @@ spec:
           ports:
             - containerPort: 6379
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -75,7 +68,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -83,12 +75,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis:3.0
-      generation: null
-      importPolicy: {}
       name: "3.0"
       referencePolicy:
         type: ""
@@ -97,7 +86,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -105,11 +93,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: web
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/expose-default: "true"
         io.kompose.service: web
@@ -121,7 +106,6 @@ spec:
             - containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -139,7 +123,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -147,12 +130,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: tuna/docker-counter23
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -161,7 +141,6 @@ spec:
 apiVersion: v1
 kind: Route
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -172,5 +151,4 @@ spec:
   to:
     kind: Service
     name: web
-    weight: null
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end-tcp
   name: front-end-tcp
@@ -20,7 +19,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -29,10 +27,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: front-end
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
@@ -47,6 +43,5 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -20,7 +19,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -29,10 +27,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: front-end
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
@@ -47,14 +43,12 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end-tcp
   name: front-end-tcp
@@ -20,7 +19,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -28,11 +26,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: front-end
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
@@ -47,7 +42,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -65,7 +59,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -73,12 +66,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: gcr.io/google-samples/gb-frontend:v4
-      generation: null
-      importPolicy: {}
       name: v4
       referencePolicy:
         type: ""

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -20,7 +19,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -28,11 +26,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: front-end
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
@@ -47,7 +42,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -65,7 +59,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -73,12 +66,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: gcr.io/google-samples/gb-frontend:v4
-      generation: null
-      importPolicy: {}
       name: v4
       referencePolicy:
         type: ""
@@ -87,7 +77,6 @@ spec:
 apiVersion: v1
 kind: Route
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -98,5 +87,4 @@ spec:
   to:
     kind: Service
     name: front-end
-    weight: null
 

--- a/script/test/fixtures/fsgroup/output-k8s.yaml
+++ b/script/test/fixtures/fsgroup/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: pgadmin
   name: pgadmin
@@ -15,7 +14,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/fsgroup-default: "true"
         io.kompose.service: pgadmin
@@ -28,7 +26,6 @@ spec:
               value: pgadmin_password
           image: dpage/pgadmin4
           name: pgadmin
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/pgadmin
               name: pgadmin-data
@@ -44,7 +41,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: pgadmin-data
   name: pgadmin-data

--- a/script/test/fixtures/fsgroup/output-os.yaml
+++ b/script/test/fixtures/fsgroup/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: pgadmin
   name: pgadmin
@@ -11,11 +10,9 @@ spec:
   selector:
     io.kompose.service: pgadmin
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/fsgroup-default: "true"
         io.kompose.service: pgadmin
@@ -28,7 +25,6 @@ spec:
               value: pgadmin_password
           image: ' '
           name: pgadmin
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/pgadmin
               name: pgadmin-data
@@ -55,7 +51,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: pgadmin
   name: pgadmin
@@ -63,12 +58,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: dpage/pgadmin4
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -77,7 +69,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: pgadmin-data
   name: pgadmin-data

--- a/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mongo
   name: mongo
@@ -18,7 +17,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mysql
   name: mysql
@@ -34,7 +32,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgresql
   name: postgresql
@@ -50,7 +47,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -66,7 +62,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mongo
   name: mongo
@@ -75,10 +70,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: mongo
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mongo
@@ -101,14 +94,12 @@ spec:
             tcpSocket:
               port: 9090
             timeoutSeconds: 1
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mysql
   name: mysql
@@ -117,10 +108,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: mysql
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mysql
@@ -143,14 +132,12 @@ spec:
             tcpSocket:
               port: 9091
             timeoutSeconds: 2
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgresql
   name: postgresql
@@ -159,10 +146,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: postgresql
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: postgresql
@@ -187,14 +172,12 @@ spec:
               port: 8080
             periodSeconds: 10
             timeoutSeconds: 1
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -203,10 +186,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: redis
@@ -232,6 +213,5 @@ spec:
             failureThreshold: 5
             periodSeconds: 10
             timeoutSeconds: 1
-          resources: {}
       restartPolicy: Always
 

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mongo
   name: mongo
@@ -18,7 +17,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mysql
   name: mysql
@@ -34,7 +32,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgresql
   name: postgresql
@@ -50,7 +47,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -66,7 +62,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mongo
   name: mongo
@@ -74,11 +69,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: mongo
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mongo
@@ -101,7 +93,6 @@ spec:
             tcpSocket:
               port: 9090
             timeoutSeconds: 1
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -119,7 +110,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mongo
   name: mongo
@@ -127,12 +117,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: mongo
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -141,7 +128,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mysql
   name: mysql
@@ -149,11 +135,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: mysql
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mysql
@@ -176,7 +159,6 @@ spec:
             tcpSocket:
               port: 9091
             timeoutSeconds: 2
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -194,7 +176,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: mysql
   name: mysql
@@ -202,12 +183,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: mysql
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -216,7 +194,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgresql
   name: postgresql
@@ -224,11 +201,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: postgresql
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: postgresql
@@ -253,7 +227,6 @@ spec:
               port: 8080
             periodSeconds: 10
             timeoutSeconds: 1
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -271,7 +244,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgresql
   name: postgresql
@@ -279,12 +251,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: postgresql
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -293,7 +262,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -301,11 +269,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/healthcheck-default: "true"
         io.kompose.service: redis
@@ -331,7 +296,6 @@ spec:
             failureThreshold: 5
             periodSeconds: 10
             timeoutSeconds: 1
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -349,7 +313,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -357,12 +320,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""

--- a/script/test/fixtures/host-port-protocol/output-k8s.yaml
+++ b/script/test/fixtures/host-port-protocol/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -19,7 +18,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -28,10 +26,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: nginx
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/host-port-protocol-default: "true"
         io.kompose.service: nginx
@@ -43,7 +39,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 

--- a/script/test/fixtures/host-port-protocol/output-os.yaml
+++ b/script/test/fixtures/host-port-protocol/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -14,12 +13,10 @@ spec:
   selector:
     io.kompose.service: nginx
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -27,11 +24,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: nginx
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/host-port-protocol-default: "true"
         io.kompose.service: nginx
@@ -43,7 +37,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -57,12 +50,10 @@ spec:
           name: nginx:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -70,14 +61,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/multiple-files/output-k8s.yaml
+++ b/script/test/fixtures/multiple-files/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: bar
   name: bar
@@ -11,10 +10,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: bar
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-files-default: "true"
         io.kompose.service: bar
@@ -22,7 +19,6 @@ spec:
       containers:
         - image: bar
           name: bar
-          resources: {}
       restartPolicy: Always
 
 
@@ -30,7 +26,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -39,10 +34,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: foo
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-files-default: "true"
         io.kompose.service: foo
@@ -50,7 +43,6 @@ spec:
       containers:
         - image: foo
           name: foo
-          resources: {}
       restartPolicy: Always
 
 

--- a/script/test/fixtures/multiple-files/output-os.yaml
+++ b/script/test/fixtures/multiple-files/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: bar
   name: bar
@@ -10,11 +9,8 @@ spec:
   replicas: 99
   selector:
     io.kompose.service: bar
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-files-default: "true"
         io.kompose.service: bar
@@ -22,7 +18,6 @@ spec:
       containers:
         - image: ' '
           name: bar
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -36,12 +31,10 @@ spec:
           name: bar:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: bar
   name: bar
@@ -49,22 +42,17 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: bar
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -72,11 +60,8 @@ spec:
   replicas: 3
   selector:
     io.kompose.service: foo
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-files-default: "true"
         io.kompose.service: foo
@@ -84,7 +69,6 @@ spec:
       containers:
         - image: ' '
           name: foo
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -98,12 +82,10 @@ spec:
           name: foo:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -111,14 +93,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: foo
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -15,7 +14,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: db
@@ -23,7 +21,6 @@ spec:
       containers:
         - image: mysql
           name: db
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: db-data
@@ -37,7 +34,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db-data
   name: db-data
@@ -52,7 +48,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -65,7 +60,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: web
@@ -73,7 +67,6 @@ spec:
       containers:
         - image: nginx
           name: web
-          resources: {}
           volumeMounts:
             - mountPath: /etc/tls
               name: web-cm0
@@ -99,7 +92,6 @@ data:
   a.key: test-key-data....
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm0
@@ -112,7 +104,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm1

--- a/script/test/fixtures/multiple-type-volumes/output-os.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -11,11 +10,9 @@ spec:
   selector:
     io.kompose.service: db
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: db
@@ -23,7 +20,6 @@ spec:
       containers:
         - image: ' '
           name: db
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: db-data
@@ -48,7 +44,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -56,12 +51,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: mysql
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -70,7 +62,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db-data
   name: db-data
@@ -85,7 +76,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -94,11 +84,9 @@ spec:
   selector:
     io.kompose.service: web
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: web
@@ -106,7 +94,6 @@ spec:
       containers:
         - image: ' '
           name: web
-          resources: {}
           volumeMounts:
             - mountPath: /etc/tls
               name: web-cm0
@@ -140,7 +127,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -148,12 +134,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -165,7 +148,6 @@ data:
   a.key: test-key-data....
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm0
@@ -178,7 +160,6 @@ kind: ConfigMap
 metadata:
   annotations:
     use-subpath: "true"
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web-cm1

--- a/script/test/fixtures/namespace/output-k8s.yaml
+++ b/script/test/fixtures/namespace/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -20,17 +19,14 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  creationTimestamp: null
   name: web
   namespace: web
-spec: {}
 
 
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -40,10 +36,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: web
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/namespace-default: "true"
         io.kompose.service: web
@@ -55,7 +49,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 

--- a/script/test/fixtures/namespace/output-os.yaml
+++ b/script/test/fixtures/namespace/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -15,22 +14,17 @@ spec:
   selector:
     io.kompose.service: web
 
-
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  creationTimestamp: null
   name: web
   namespace: web
-spec: {}
-
 
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -39,11 +33,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: web
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/namespace-default: "true"
         io.kompose.service: web
@@ -55,7 +46,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -69,12 +59,10 @@ spec:
           name: web:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: web
   name: web
@@ -83,14 +71,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/network-policies/output-k8s.yaml
+++ b/script/test/fixtures/network-policies/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -19,7 +18,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -28,10 +26,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: nginx
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/network-policies-web: "true"
         io.kompose.service: nginx
@@ -43,7 +39,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 
@@ -51,7 +46,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  creationTimestamp: null
   name: network-policies-web
 spec:
   ingress:

--- a/script/test/fixtures/read-only/output-k8s.yaml
+++ b/script/test/fixtures/read-only/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: test
   name: test
@@ -19,7 +18,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: test
   name: test
@@ -28,10 +26,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: test
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/read-only-default: "true"
         io.kompose.service: test
@@ -43,7 +39,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
           securityContext:
             readOnlyRootFilesystem: true
       restartPolicy: Always

--- a/script/test/fixtures/read-only/output-os.yaml
+++ b/script/test/fixtures/read-only/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: test
   name: test
@@ -14,12 +13,10 @@ spec:
   selector:
     io.kompose.service: test
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: test
   name: test
@@ -27,11 +24,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: test
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/read-only-default: "true"
         io.kompose.service: test
@@ -43,7 +37,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
           securityContext:
             readOnlyRootFilesystem: true
       restartPolicy: Always
@@ -59,12 +52,10 @@ spec:
           name: test:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: test
   name: test
@@ -72,14 +63,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: alpine
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/resources-lowercase/output-k8s.yaml
+++ b/script/test/fixtures/resources-lowercase/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -18,7 +17,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -27,10 +25,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: nginx
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/resources-lowercase-default: "true"
         io.kompose.service: nginx
@@ -42,6 +38,5 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 

--- a/script/test/fixtures/resources-lowercase/output-os.yaml
+++ b/script/test/fixtures/resources-lowercase/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -18,7 +17,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -26,11 +24,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: nginx
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/resources-lowercase-default: "true"
         io.kompose.service: nginx
@@ -42,7 +37,6 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -60,7 +54,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: nginx
   name: nginx
@@ -68,12 +61,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx:latest
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""

--- a/script/test/fixtures/service-group/output-k8s.yaml
+++ b/script/test/fixtures/service-group/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: librenms-dispatcher
   name: librenms
@@ -19,7 +18,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: librenms-dispatcher
   name: librenms-dispatcher
@@ -32,7 +30,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/service-group-default: "true"
         io.kompose.service: librenms-dispatcher
@@ -42,7 +39,6 @@ spec:
             - name: TZ
           image: librenms/dispatcher:latest
           name: dispatcher
-          resources: {}
           volumeMounts:
             - mountPath: /data
               name: librenms-dispatcher-claim0
@@ -54,7 +50,6 @@ spec:
             - containerPort: 8000
               hostPort: 8000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /data
               name: librenms-dispatcher-claim0
@@ -70,7 +65,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: librenms-dispatcher-claim0
   name: librenms-dispatcher-claim0

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front_end
@@ -18,7 +17,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end
@@ -27,10 +25,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: front-end
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/single-file-output-default: "true"
         io.kompose.service: front-end
@@ -45,14 +41,12 @@ spec:
             - containerPort: 80
               hostPort: 80
               protocol: TCP
-          resources: {}
       restartPolicy: Always
 
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: front-end
   name: front-end

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -21,7 +20,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: wordpress
   name: wordpress
@@ -40,7 +38,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -52,7 +49,6 @@ spec:
   serviceName: db
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/statefulset-default: "true"
         io.kompose.service: db
@@ -73,15 +69,12 @@ spec:
             - containerPort: 3306
               hostPort: 3306
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: db-data
       restartPolicy: Always
-  updateStrategy: {}
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         labels:
           io.kompose.service: db-data
         name: db-data
@@ -96,7 +89,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: wordpress
   name: wordpress
@@ -108,7 +100,6 @@ spec:
   serviceName: wordpress
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/statefulset-default: "true"
         io.kompose.service: wordpress
@@ -129,15 +120,12 @@ spec:
             - containerPort: 80
               hostPort: 8000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /var/www/html
               name: wordpress-data
       restartPolicy: Always
-  updateStrategy: {}
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         labels:
           io.kompose.service: wordpress-data
         name: wordpress-data

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -19,7 +18,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: wordpress
   name: wordpress
@@ -36,7 +34,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -48,7 +45,6 @@ spec:
   serviceName: db
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/statefulset-default: "true"
         io.kompose.service: db
@@ -69,15 +65,12 @@ spec:
             - containerPort: 3306
               hostPort: 3306
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: db-data
       restartPolicy: Always
-  updateStrategy: {}
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         labels:
           io.kompose.service: db-data
         name: db-data
@@ -92,7 +85,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -101,11 +93,9 @@ spec:
   selector:
     io.kompose.service: db
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/statefulset-default: "true"
         io.kompose.service: db
@@ -126,7 +116,6 @@ spec:
             - containerPort: 3306
               hostPort: 3306
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: db-data
@@ -148,7 +137,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -156,12 +144,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: mysql:5.7
-      generation: null
-      importPolicy: {}
       name: "5.7"
       referencePolicy:
         type: ""
@@ -171,7 +156,6 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: wordpress
   name: wordpress
@@ -183,7 +167,6 @@ spec:
   serviceName: wordpress
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/statefulset-default: "true"
         io.kompose.service: wordpress
@@ -204,15 +187,12 @@ spec:
             - containerPort: 80
               hostPort: 8000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /var/www/html
               name: wordpress-data
       restartPolicy: Always
-  updateStrategy: {}
   volumeClaimTemplates:
     - metadata:
-        creationTimestamp: null
         labels:
           io.kompose.service: wordpress-data
         name: wordpress-data
@@ -227,7 +207,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: wordpress
   name: wordpress
@@ -236,11 +215,9 @@ spec:
   selector:
     io.kompose.service: wordpress
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/statefulset-default: "true"
         io.kompose.service: wordpress
@@ -261,7 +238,6 @@ spec:
             - containerPort: 80
               hostPort: 8000
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: /var/www/html
               name: wordpress-data
@@ -283,7 +259,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: wordpress
   name: wordpress
@@ -291,12 +266,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: wordpress:latest
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""

--- a/script/test/fixtures/v2/output-k8s.yaml
+++ b/script/test/fixtures/v2/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -93,7 +92,6 @@ kind: Service
 metadata:
   annotations:
     kompose.service.type: loadbalancer
-  creationTimestamp: null
   labels:
     io.kompose.service: redis-tcp
   name: redis-tcp
@@ -112,7 +110,6 @@ kind: Service
 metadata:
   annotations:
     kompose.service.type: loadbalancer
-  creationTimestamp: null
   labels:
     io.kompose.service: redis-udp
   name: redis-udp
@@ -130,7 +127,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.network/v2-default: "true"
     io.kompose.service: foo
@@ -233,7 +229,6 @@ kind: Deployment
 metadata:
   annotations:
     kompose.service.type: loadbalancer
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -242,12 +237,10 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
       annotations:
         kompose.service.type: loadbalancer
-      creationTimestamp: null
       labels:
         io.kompose.network/v2-default: "true"
         io.kompose.service: redis

--- a/script/test/fixtures/v2/output-os.yaml
+++ b/script/test/fixtures/v2/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -87,14 +86,12 @@ spec:
   selector:
     io.kompose.service: foo
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
     kompose.service.type: loadbalancer
-  creationTimestamp: null
   labels:
     io.kompose.service: redis-tcp
   name: redis-tcp
@@ -107,14 +104,12 @@ spec:
     io.kompose.service: redis
   type: LoadBalancer
 
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
     kompose.service.type: loadbalancer
-  creationTimestamp: null
   labels:
     io.kompose.service: redis-udp
   name: redis-udp
@@ -128,12 +123,10 @@ spec:
     io.kompose.service: redis
   type: LoadBalancer
 
-
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.network/v2-default: "true"
     io.kompose.service: foo
@@ -230,14 +223,12 @@ spec:
     supplementalGroups:
       - 1234
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   annotations:
     kompose.service.type: loadbalancer
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -245,11 +236,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/v2-default: "true"
         io.kompose.service: redis
@@ -279,12 +267,10 @@ spec:
           name: redis:3.0
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -292,14 +278,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis:3.0
-      generation: null
-      importPolicy: {}
       name: "3.0"
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/v3.0/output-k8s.yaml
+++ b/script/test/fixtures/v3.0/output-k8s.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   annotations:
     kompose.service.type: headless
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -21,7 +20,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -30,10 +28,8 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: foo
-  strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/app-network: "true"
         io.kompose.network/v30-normalized-network: "true"
@@ -47,7 +43,6 @@ spec:
             - echo Hello Foo
           image: foo:latest
           name: foo
-          resources: {}
       restartPolicy: Always
 
 ---
@@ -56,7 +51,6 @@ kind: Deployment
 metadata:
   annotations:
     kompose.service.type: headless
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -65,12 +59,10 @@ spec:
   selector:
     matchLabels:
       io.kompose.service: redis
-  strategy: {}
   template:
     metadata:
       annotations:
         kompose.service.type: headless
-      creationTimestamp: null
       labels:
         io.kompose.network/v30-default: "true"
         io.kompose.service: redis
@@ -85,6 +77,5 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1
           name: redis
-          resources: {}
       restartPolicy: Always
 

--- a/script/test/fixtures/v3.0/output-os.yaml
+++ b/script/test/fixtures/v3.0/output-os.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   annotations:
     kompose.service.type: headless
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -17,12 +16,10 @@ spec:
   selector:
     io.kompose.service: redis
 
-
 ---
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -34,7 +31,6 @@ spec:
     resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/app-network: "true"
         io.kompose.network/v30-normalized-network: "true"
@@ -48,7 +44,6 @@ spec:
             - echo Hello Foo
           image: ' '
           name: foo
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -62,12 +57,10 @@ spec:
           name: foo:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: foo
   name: foo
@@ -75,16 +68,12 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: foo:latest
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 
 ---
 apiVersion: apps.openshift.io/v1
@@ -92,7 +81,6 @@ kind: DeploymentConfig
 metadata:
   annotations:
     kompose.service.type: headless
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -100,11 +88,8 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: redis
-  strategy:
-    resources: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/v30-default: "true"
         io.kompose.service: redis
@@ -119,7 +104,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 1
           name: redis
-          resources: {}
       restartPolicy: Always
   test: false
   triggers:
@@ -133,12 +117,10 @@ spec:
           name: redis:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: redis
   name: redis
@@ -146,14 +128,10 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: redis
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
-
 

--- a/script/test/fixtures/vols-subpath/output-k8s.yaml
+++ b/script/test/fixtures/vols-subpath/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgres
   name: postgres
@@ -15,7 +14,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/vols-subpath-default: "true"
         io.kompose.service: postgres
@@ -30,7 +28,6 @@ spec:
               value: dumb_postgres_user
           image: postgres
           name: postgres
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgres-data
@@ -45,7 +42,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgres-data
   name: postgres-data

--- a/script/test/fixtures/vols-subpath/output-os.yaml
+++ b/script/test/fixtures/vols-subpath/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgres
   name: postgres
@@ -11,11 +10,9 @@ spec:
   selector:
     io.kompose.service: postgres
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/vols-subpath-default: "true"
         io.kompose.service: postgres
@@ -30,7 +27,6 @@ spec:
               value: dumb_postgres_user
           image: ' '
           name: postgres
-          resources: {}
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgres-data
@@ -56,7 +52,6 @@ spec:
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgres
   name: postgres
@@ -64,12 +59,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: postgres
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -78,7 +70,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: postgres-data
   name: postgres-data

--- a/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -18,7 +17,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -31,7 +29,6 @@ spec:
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/windows-default: "true"
         io.kompose.service: db
@@ -42,7 +39,6 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: D:\config
               name: db-claim0
@@ -56,7 +52,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db-claim0
   name: db-claim0

--- a/script/test/fixtures/volume-mounts/windows/output-os.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-os.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -19,7 +18,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -28,11 +26,9 @@ spec:
   selector:
     io.kompose.service: db
   strategy:
-    resources: {}
     type: Recreate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         io.kompose.network/windows-default: "true"
         io.kompose.service: db
@@ -43,7 +39,6 @@ spec:
           ports:
             - containerPort: 80
               protocol: TCP
-          resources: {}
           volumeMounts:
             - mountPath: D:\config
               name: db-claim0
@@ -64,12 +59,10 @@ spec:
           name: db:latest
       type: ImageChange
 
-
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db
@@ -77,12 +70,9 @@ spec:
   lookupPolicy:
     local: false
   tags:
-    - annotations: null
-      from:
+    - from:
         kind: DockerImage
         name: nginx:latest
-      generation: null
-      importPolicy: {}
       name: latest
       referencePolicy:
         type: ""
@@ -92,7 +82,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: db-claim0
   name: db-claim0


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR transforms yaml output by removing map[string]interfaces{} with no keys, or the nil fields. This PR utilizes the current implementation of the yaml transformation process in the "kompose" `(1) object ->  (2) []byte (json) -> (3) interface{} -> (4) []byte (yaml)`. Between steps 3 and 4, there is a chance to clean the data structure by removing any empty fields.

#### Which issue(s) this PR fixes:
Fixes #1758

#### Special notes for your reviewer:

IMHO, The empty artifacts  (such as strategy {} , resources: {},...) are present because we have e.g.  in the [`DeploymentSpec.Strategy`](https://github.com/kubernetes/kubernetes/blob/89dfbebe2e823bd0b13e4b65b8460a058c7258a3/pkg/apis/apps/types.go#L385) struct not the reference (a pointer) to the struct, since this change would be outside of the kompose scope and I am not sure if it is feasible, I've decided to fix it by removing all empty fields.

Is this correct approach I should proceed with, or should I open (or search if a ticket exists) in the k8s/kubernetes repo for change in the API app types?