### PR TITLE
fix issue 1778

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -946,3 +946,15 @@ func GetContainerArgs(service kobject.ServiceConfig) []string {
 	}
 	return args
 }
+
+// GetFileName extracts the file name from a given file path or file name.
+// If the input fileName contains a "/", it retrieves the substring after the last "/".
+// The function does not format the file name further, as it may contain periods or other valid characters.
+// Returns the extracted file name.
+func GetFileName(fileName string) string {
+	if strings.Contains(fileName, "/") {
+		fileName = fileName[strings.LastIndex(fileName, "/")+1:]
+	}
+	// Not format filename because can begin with .fileName
+	return fileName
+}

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -582,6 +582,7 @@ func (k *Kubernetes) CreateSecrets(komposeObject kobject.KomposeObject) ([]*api.
 				return nil, err
 			}
 			data := []byte(dataString)
+			fileName := GetFileName(config.File)
 			secret := &api.Secret{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Secret",
@@ -592,7 +593,7 @@ func (k *Kubernetes) CreateSecrets(komposeObject kobject.KomposeObject) ([]*api.
 					Labels: transformer.ConfigLabels(name),
 				},
 				Type: api.SecretTypeOpaque,
-				Data: map[string][]byte{name: data},
+				Data: map[string][]byte{fileName: data},
 			}
 			objects = append(objects, secret)
 		} else {

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -1238,13 +1238,14 @@ func TestKubernetes_CreateSecrets(t *testing.T) {
 	}
 }
 
+// struct defines the configuration parameters required for creating a secret
 type SecretsConfig struct {
 	nameSecretConfig string
 	nameSecret       string
 	pathFile         string
 }
 
-// generate
+// creates a new instance of types.Secrets based on the provided SecretsConfig parameter
 func newSecrets(stringsSecretConfig SecretsConfig) types.Secrets {
 	return types.Secrets{
 		stringsSecretConfig.nameSecretConfig: types.SecretConfig{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
* fix issue https://github.com/kubernetes/kompose/issues/1778 
* add tests with hardcoded values to mokup file access with a file that exist in repo

Fixes #1778

#### Special notes for your reviewer:
i runned action Kompose CI, but get error from action, i checked result and expect and it's very similar 
https://github.com/sosan/kompose/actions/runs/7479241247/job/20355974505
```
convert::expect_success: 
Running: 'kompose -f /home/runner/work/kompose/kompose/script/test/fixtures/configmap-pod/docker-compose.yml convert --stdout --with-kompose-annotation=false' expected_output: '/home/runner/work/kompose/kompose/script/test/fixtures/configmap-pod/output-k8s.yaml'_ __ __ _| |_ _ / _|/ _| between /home/runner/work/kompose/kompose/script/test/fixtures/configmap-pod/output-k8s.yaml, 
four documents / _' | | | | |_| |_ and /tmp/kompose/test-stdout, 
four documents | (_| | |_| | _| _| \__,_|\__, |_| |_| returned five differences |___/ metadata (Service/default/redis) 

one map entry removed: creationTimestamp: null metadata (Pod/default/redis) - 
one map entry removed: creationTimestamp: null spec.containers.redis (Pod/default/redis) - 
one map entry removed: resources: {} metadata (ConfigMap/default/foo-env) - 
one map entry removed: creationTimestamp: null metadata (ConfigMap/default/bar-env) - 
one map entry removed: creationTimestamp: null
FAIL: converted output does not match
```
 