### PR TITLE
docs: replace gcr.io with nginx docker image

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -428,9 +428,7 @@ version: "3.3"
 
 services:
   front-end:
-    image: gcr.io/google-samples/gb-frontend:v4
-    environment:
-      - GET_HOSTS_FROM=dns
+    image: nginx
     ports:
       - 80:80
     labels:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind documentation

#### What this PR does / why we need it:
This PR aims to replace the `gcr.io/google-samples/gb-frontend:v4` with the `nginx` image since the former is not found (probably deleted).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1789
