### PR TITLE
docs(cli): introduce examples in the kompose command

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -79,6 +79,9 @@ var (
 var convertCmd = &cobra.Command{
 	Use:   "convert",
 	Short: "Convert a Docker Compose file",
+	Example: `  kompose --file docker-voting.yml convert
+  kompose -f docker-compose.yml -f docker-guestbook.yml convert
+  kompose --provider openshift --file docker-voting.yml convert`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 
 		// Check that build-config wasn't passed in with --provider=kubernetes

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -79,9 +79,9 @@ var (
 var convertCmd = &cobra.Command{
 	Use:   "convert",
 	Short: "Convert a Docker Compose file",
-	Example: `  kompose --file docker-voting.yml convert
-  kompose -f docker-compose.yml -f docker-guestbook.yml convert
-  kompose --provider openshift --file docker-voting.yml convert`,
+	Example: `  kompose --file compose.yaml convert
+  kompose -f first.yaml -f second.yaml convert
+  kompose --provider openshift --file compose.yaml convert`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 
 		// Check that build-config wasn't passed in with --provider=kubernetes

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,9 +53,9 @@ var RootCmd = &cobra.Command{
 	Use:           "kompose",
 	Short:         "A tool helping Docker Compose users move to Kubernetes",
 	Long:          `Kompose is a tool to help users who are familiar with docker-compose move to Kubernetes.`,
-	Example: `  kompose --file docker-voting.yml convert
-  kompose -f docker-compose.yml -f docker-guestbook.yml convert
-  kompose --provider openshift --file docker-voting.yml convert
+	Example: `  kompose --file compose.yaml convert
+  kompose -f first.yaml -f second.yaml convert
+  kompose --provider openshift --file compose.yaml convert
   kompose completion bash`,
 	SilenceErrors: true,
 	// PersistentPreRun will be "inherited" by all children and ran before *every* command unless

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,9 +50,9 @@ var (
 
 // RootCmd root level flags and commands
 var RootCmd = &cobra.Command{
-	Use:           "kompose",
-	Short:         "A tool helping Docker Compose users move to Kubernetes",
-	Long:          `Kompose is a tool to help users who are familiar with docker-compose move to Kubernetes.`,
+	Use:   "kompose",
+	Short: "A tool helping Docker Compose users move to Kubernetes",
+	Long:  `Kompose is a tool to help users who are familiar with docker-compose move to Kubernetes.`,
 	Example: `  kompose --file compose.yaml convert
   kompose -f first.yaml -f second.yaml convert
   kompose --provider openshift --file compose.yaml convert

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,10 @@ var RootCmd = &cobra.Command{
 	Use:           "kompose",
 	Short:         "A tool helping Docker Compose users move to Kubernetes",
 	Long:          `Kompose is a tool to help users who are familiar with docker-compose move to Kubernetes.`,
+	Example: `  kompose --file docker-voting.yml convert
+  kompose -f docker-compose.yml -f docker-guestbook.yml convert
+  kompose --provider openshift --file docker-voting.yml convert
+  kompose completion bash`,
 	SilenceErrors: true,
 	// PersistentPreRun will be "inherited" by all children and ran before *every* command unless
 	// the child has overridden the functionality. This functionality was implemented to check / modify


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

This PR adds few basic examples to the cli command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1717

#### Special notes for your reviewer:

I've considered  to update `Long` instead adding the `Examples` field. However, it looked more clear to introduce these few examples. Maybe later, there will be more content to add into Long with specific examples.

The result of running `kompose`
```
Kompose is a tool to help users who are familiar with docker-compose move to Kubernetes.

Usage:
  kompose [command]

Examples:
  kompose --file compose.yaml convert
  kompose -f first.yaml -f second.yaml convert
  kompose --provider openshift --file compose.yaml convert
  kompose completion bash

Available Commands:
  completion  Output shell completion code
  convert     Convert a Docker Compose file
  help        Help about any command
  version     Print the version of Kompose

Flags:
      --error-on-warning    Treat any warning as an error
  -f, --file strings        Specify an alternative compose file
  -h, --help                help for kompose
      --provider string     Specify a provider. Kubernetes or OpenShift. (default "kubernetes")
      --suppress-warnings   Suppress all warnings
  -v, --verbose             verbose output

Use "kompose [command] --help" for more information about a command.
```

The result of `kompose convert --help`:
```
./kompose convert --help
Convert a Docker Compose file

Usage:
  kompose convert [flags]

Examples:
  kompose --file compose.yaml convert
  kompose -f first.yaml -f second.yaml convert
  kompose --provider openshift --file compose.yaml convert

Kubernetes Flags:
  -c, --chart                    Create a Helm chart for converted objects
      --controller               Set the output controller ("deployment"|"daemonSet"|"replicationController")
      --service-group-mode       Group multiple service to create single workload by "label"("kompose.service.group") or "volume"(shared volumes)
      --service-group-name       Using with --service-group-mode=volume to specific a final service name for the group

OpenShift Flags:
      --build-branch             Specify repository branch to use for buildconfig (default is current branch name)
      --build-repo               Specify source repository for buildconfig (default is current branch's remote url)
      --insecure-repository      Specify to use insecure docker repository while generating Openshift image stream object

Flags:
      --build string                 Set the type of build ("local"|"build-config"(OpenShift only)|"none") (default "none")
      --build-command string         Set the command used to build the container image. override the docker build command.Should be used in conjuction with --push-command flag.
      --controller string            Set the output controller ("deployment"|"daemonSet"|"replicationController")
      --generate-network-policies    Specify whether to generate network policies or not.
  -h, --help                         help for convert
      --indent int                   Spaces length to indent generated yaml files (default 2)
  -j, --json                         Generate resource files into JSON format
  -n, --namespace string             Specify the namespace of the generated resources
  -o, --out string                   Specify a file name or directory to save objects to (if path does not exist, a file will be created)
      --profile stringArray          Specify the profile to use, can use multiple profiles
      --push-command string          Set the command used to push the container image. override the docker push command. Should be used in conjuction with --build-command flag.
      --push-image                   If we should push the docker image we built
      --push-image-registry string   Specify registry for pushing image, which will override registry from image name.
      --pvc-request-size string      Specify the size of pvc storage requests in the generated resource spec
      --replicas int                 Specify the number of replicas in the generated resource spec (default 1)
      --secrets-as-files             Always convert docker-compose secrets into files instead of symlinked directories.
      --service-group-mode label     Group multiple service to create single workload by label(`kompose.service.group`) or `volume`(shared volumes)
      --service-group-name string    Using with --service-group-mode=volume to specific a final service name for the group
      --stdout                       Print converted objects to stdout
      --volumes string               Volumes to be generated ("persistentVolumeClaim"|"emptyDir"|"hostPath" | "configMap") (default "persistentVolumeClaim")
      --with-kompose-annotation      Add kompose annotations to generated resource (default true)

Global Flags:
      --error-on-warning    Treat any warning as an error
  -f, --file strings        Specify an alternative compose file
      --provider string     Specify a provider. Kubernetes or OpenShift. (default "kubernetes")
      --suppress-warnings   Suppress all warnings
  -v, --verbose             verbose output
```