### PR TITLE
docs(1815): add trademarks link ref to linux foundation

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -7,6 +7,14 @@
       Apache License 2.0 licensed project
       <br>
       © {{ site.year }} Kompose Authors -- All Rights Reserved
+      <br />
+      <a
+        class="trademarks"
+        href="https://www.linuxfoundation.org/legal/trademark-usage"
+        target="_blank"
+        ref="noopener"
+        >Trademarks</a
+      >
     </span>
   </div>
   <div class="container">

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -3696,13 +3696,22 @@ font-family: "Open Sans";
 .code-example {
   margin: 0;
   padding: 0;
-  margin-bottom 0px !important;
+  margin-bottom: 0px !important;
   background-color: transparent !important;
 }
 
 .copyright {
   color: #fff !important;
   font-size:13px;
+  padding-bottom: 12px;
+}
+
+a.trademarks {
+	color: #fff !important;
+	font-weight:600;
+	display: inline-block;
+	text-decoration: underline;
+	padding: 0.8rem 0;
 }
 
 .highlight {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

This PR solves the trademark criteria on [CLOMonitor](https://clomonitor.io/search?foundation=cncf&not_passing_check=trademark_disclaimer&page=1).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1815

#### Special notes for your reviewer:
This PR includes incorect css - missing `:`: `margin-bottom: 0px !important;`

![image](https://github.com/kubernetes/kompose/assets/4950200/ccab97b0-2538-4be4-bc07-c5767cf12ea9)
