### PR TITLE
fix client/convert (issue https://github.com/kubernetes/kompose/issue…

### DIFF
--- a/client/convert.go
+++ b/client/convert.go
@@ -64,7 +64,7 @@ func (k *Kompose) setDefaultValues(options ConvertOptions) ConvertOptions {
 	buildDefaultValue := "none"
 	volumeTypeDefaultValue := "persistentVolumeClaim"
 	withKomposeAnnotationsDefaultValue := true
-	kubernetesControllerDefaultValue := "deployment"
+	kubernetesControllerDefaultValue := ""
 	kubernetesServiceGroupModeDefaultValue := ""
 
 	if options.Replicas == nil {
@@ -126,7 +126,7 @@ func (k *Kompose) validateOptions(options ConvertOptions) error {
 
 	if kubernetesProvider, ok := options.Provider.(Kubernetes); ok {
 		kubernetesController := kubernetesProvider.Controller
-		if *kubernetesController != string(DEPLOYMENT) && *kubernetesController != string(DAEMONSET) && *kubernetesController != string(REPLICATION_CONTROLLER) {
+		if *kubernetesController != "" && *kubernetesController != string(DEPLOYMENT) && *kubernetesController != string(DAEMONSET) && *kubernetesController != string(REPLICATION_CONTROLLER) {
 			return fmt.Errorf(
 				"unexpected Value for Kubernetes Controller field. Possible values are: %v, %v, and %v", string(DEPLOYMENT), string(DAEMONSET), string(REPLICATION_CONTROLLER),
 			)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
* Client Default Controller should be empty string ("") and empty string should be a valid value.


#### Which issue(s) this PR fixes:
Fixes [#1818](https://github.com/kubernetes/kompose/issues/1818)

#### Special notes for your reviewer:
@AhmedGrati I think you should review this since it's your feature.