### PR TITLE
#1821 update Dockerfile to alwyas use head Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM alpine:3.9 as builder
+# Alpine Builder
+FROM alpine as builder
 
 RUN apk add --no-cache curl
 COPY ./build/VERSION VERSION
-RUN version=$(cat VERSION) && curl -L "https://github.com/kubernetes/kompose/releases/download/v${version}/kompose-linux-amd64" -o kompose
+RUN \
+  version=$(cat VERSION) && \
+  ARCH=$(uname -m | sed 's/armv7l/arm/g' | sed 's/aarch64/arm64/g' | sed 's/x86_64/amd64/g') && \
+  curl -L \
+    "https://github.com/kubernetes/kompose/releases/download/v${version}/kompose-linux-${ARCH}" \
+    -o kompose && \
+  chmod +x kompose
 
-FROM alpine:3.9
+# Runtime
+FROM alpine
 
 COPY --from=builder /kompose /usr/bin/kompose
-RUN chmod +x /usr/bin/kompose


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This updates the current Dockerfile to support aarch64 and armv7 as well, it also bumps to always use head Alpine instead of the previous hard coded 3.9. Given your instructions only use busybox for the ability to cd into the /opt directory this can likely be based down to scratch with some minor doc updates, but that is not the purpose of this PR and the space savings are negligible to potentially break external workflows. 

#### Which issue(s) this PR fixes:

Fixes #1821