### PR TITLE
requests and limits by default as flag --requestslimits

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -129,6 +129,7 @@ var convertCmd = &cobra.Command{
 			BuildCommand:                BuildCommand,
 			PushCommand:                 PushCommand,
 			Namespace:                   ConvertNamespace,
+			CreateDefaultLimitsRequests: GlobalDefaultLimitsRequests,
 		}
 
 		if ServiceGroupMode == "" && MultipleContainerMode {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,11 +41,12 @@ func (errorOnWarningHook) Fire(entry *log.Entry) error {
 
 // TODO: comment
 var (
-	GlobalProvider         string
-	GlobalVerbose          bool
-	GlobalSuppressWarnings bool
-	GlobalErrorOnWarning   bool
-	GlobalFiles            []string
+	GlobalProvider              string
+	GlobalVerbose               bool
+	GlobalSuppressWarnings      bool
+	GlobalErrorOnWarning        bool
+	GlobalFiles                 []string
+	GlobalDefaultLimitsRequests bool
 )
 
 // RootCmd root level flags and commands
@@ -111,4 +112,5 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&GlobalErrorOnWarning, "error-on-warning", false, "Treat any warning as an error")
 	RootCmd.PersistentFlags().StringSliceVarP(&GlobalFiles, "file", "f", []string{}, "Specify an alternative compose file")
 	RootCmd.PersistentFlags().StringVar(&GlobalProvider, "provider", "kubernetes", "Specify a provider. Kubernetes or OpenShift.")
+	RootCmd.PersistentFlags().BoolVarP(&GlobalDefaultLimitsRequests, "limitsrequests", "l", false, "Output default Limits and Requests")
 }

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -92,6 +92,8 @@ type ConvertOptions struct {
 	ServiceGroupName        string
 	SecretsAsFiles          bool
 	GenerateNetworkPolicies bool
+
+	CreateDefaultLimitsRequests bool
 }
 
 // IsPodController indicate if the user want to use a controller


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What this PR does / why we need it:
The `getResourceRequests` and `getResourceLimits` functions now provide predefined CPU and memory requests, so you don't need to fill them manually.
We also added the -l or --limitsrequests flag to force the requests and limits to be generated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


#### Special notes for your reviewer:
