### PR TITLE
chore: replace AhmedGrati with TessaIO

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ reviewers:
   - ngtuna
   - sebgoa
   - hangyan
-  - AhmedGrati
+  - TessaIO
 
 approvers:
   - cdrage
@@ -17,4 +17,4 @@ approvers:
   - ngtuna
   - sebgoa
   - hangyan
-  - AhmedGrati
+  - TessaIO


### PR DESCRIPTION
The `AhmedGrati` account is locked and should be replaced with `TessaIO`. You can check that both have the same e-mail.