### PR TITLE
customize resource name individually via labels kompose.service.name_override

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -464,7 +464,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 	for _, composeServiceConfig := range composeObject.Services {
 		// Standard import
 		// No need to modify before importation
-		name := strings.ToLower(composeServiceConfig.Name)
+		name := parseResourceName(composeServiceConfig.Name, composeServiceConfig.Labels)
 		serviceConfig := kobject.ServiceConfig{}
 		serviceConfig.Name = name
 		serviceConfig.Image = composeServiceConfig.Image
@@ -792,6 +792,10 @@ func parseKomposeLabels(labels map[string]string, serviceConfig *kobject.Service
 			}
 
 			serviceConfig.CronJobBackoffLimit = cronJobBackoffLimit
+		case LabelNameOverride:
+			// generate a valid k8s resource name
+			normalizedName := normalizeServiceNames(value)
+			serviceConfig.Name = normalizedName
 		default:
 			serviceConfig.Labels[key] = value
 		}

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/kubernetes/kompose/pkg/kobject"
 	"github.com/pkg/errors"
 
@@ -87,6 +88,8 @@ const (
 	LabelCronJobConcurrencyPolicy = "kompose.cronjob.concurrency_policy"
 	// LabelCronJobBackoffLimit defines the job backoff limit
 	LabelCronJobBackoffLimit = "kompose.cronjob.backoff_limit"
+	// LabelNameOverride defines the override resource name
+	LabelNameOverride = "kompose.service.name_override"
 )
 
 // load environment variables from compose file
@@ -193,4 +196,16 @@ func ReadFile(fileName string) ([]byte, error) {
 		return StdinData, nil
 	}
 	return os.ReadFile(fileName)
+}
+
+// Choose normalized name from resource in case exist LabelNameOverride
+// from label
+func parseResourceName(resourceName string, labels types.Labels) string {
+	// Opted to use normalizeContainerNames over normalizeServiceNames
+	// as in tests, normalization is only to lowercase.
+	normalizedName := normalizeContainerNames(resourceName)
+	if labelValue, exist := labels[LabelNameOverride]; exist {
+		normalizedName = normalizeContainerNames(labelValue)
+	}
+	return normalizedName
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What this PR does / why we need it:

this PR is the second part from #1833 and suggests labels to allow individual customization. Uses `kompose.service.name_override` label, but can change label name 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Feature #1635

#### Special notes for your reviewer:
tests `Test_parseKomposeLabels` encounters a corner case scenario where the resource name that being processed starts or ends with a hyphen '-' or any other character

// This is a corner case that is expected to fail because
// it does not account for scenarios where the string
// starts or ends with a '-' or any other character
// this test will fail with current tests
