### PR TITLE
update references to just compose

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -78,7 +78,7 @@ var (
 
 var convertCmd = &cobra.Command{
 	Use:   "convert",
-	Short: "Convert a Docker Compose file",
+	Short: "Convert a Compose file",
 	Example: `  kompose --file compose.yaml convert
   kompose -f first.yaml -f second.yaml convert
   kompose --provider openshift --file compose.yaml convert`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,7 @@ var (
 // RootCmd root level flags and commands
 var RootCmd = &cobra.Command{
 	Use:   "kompose",
-	Short: "A tool helping Docker Compose users move to Kubernetes",
+	Short: "A tool helping Compose users move to Kubernetes",
 	Long:  `Kompose is a tool to help users who are familiar with docker-compose move to Kubernetes.`,
 	Example: `  kompose --file compose.yaml convert
   kompose -f first.yaml -f second.yaml convert

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ redirect_from:
 
 ## Loader
 
-The Loader reads the input file now `kompose` supports [Docker Compose](https://docs.docker.com/compose) v1, v2 and converts it to KomposeObject.
+The Loader reads the input file now `kompose` supports [Compose](https://docs.docker.com/compose) v1, v2 and converts it to KomposeObject.
 
 Loader is represented by a Loader interface:
 

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -24,7 +24,7 @@ We're doing our best to keep it up to date as soon as possible in our releases t
 **Glossary:**
 
 - **✓:** Converts
-- **-:** Not in this Docker Compose Version
+- **-:** Not in this Compose Version
 - **n:** Not yet implemented
 - **x:** Not applicable / no 1-1 conversion
 
@@ -90,7 +90,7 @@ We're doing our best to keep it up to date as soon as possible in our releases t
 | stop_signal            | x  | x  | x  |                                                                      | Not supported within Kubernetes. See issue https://github.com/kubernetes/kubernetes/issues/30051                                  |
 | sysctls                | n  | n  | n  |                                                                      |                                                                                                                                   |
 | ulimits                | x  | x  | x  |                                                                      | Not supported within Kubernetes. See issue https://github.com/kubernetes/kubernetes/issues/3595                                   |
-| userns_mode            | x  | x  | x  |                                                                      | Not supported within Kubernetes and ignored in Docker Compose Version 3                                                           |
+| userns_mode            | x  | x  | x  |                                                                      | Not supported within Kubernetes and ignored in Compose Version 3                                                           |
 | volumes                | ✓  | ✓  | ✓  | PersistentVolumeClaim                                                | Creates a PersistentVolumeClaim. Can only be created if there is already a PersistentVolume within the cluster                    |
 | volumes: short-syntax  | ✓  | ✓  | ✓  | PersistentVolumeClaim                                                | Creates a PersistentVolumeClaim. Can only be created if there is already a PersistentVolume within the cluster                    |
 | volumes: long-syntax   | -  | -  | ✓  | PersistentVolumeClaim                                                | Creates a PersistentVolumeClaim. Can only be created if there is already a PersistentVolume within the cluster                    |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,13 +44,13 @@ Starting cluster components...
 Kubectl is now configured to use the cluster
 ```
 
-**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml), or use your own:**
+**Download an [example Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml), or use your own:**
 
 ```sh
 wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml
 ```
 
-**Convert your Docker Compose file to Kubernetes:**
+**Convert your Compose file to Kubernetes:**
 
 Run `kompose convert` in the same directory as your `compose.yaml` file.
 
@@ -134,13 +134,13 @@ Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
 ```
 
-**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml), or use your own:**
+**Download an [example Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml), or use your own:**
 
 ```sh
 wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml
 ```
 
-**Convert your Docker Compose file to OpenShift:**
+**Convert your Compose file to OpenShift:**
 
 Run `kompose convert --provider=openshift` in the same directory as your `compose.yaml` file.
 
@@ -254,13 +254,13 @@ Starting local OpenShift cluster using 'kvm' hypervisor...
 ...
 ```
 
-**Download an [example Docker Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml), or use your own:**
+**Download an [example Compose file](https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml), or use your own:**
 
 ```sh
 wget https://raw.githubusercontent.com/kubernetes/kompose/main/examples/compose.yaml
 ```
 
-**Convert your Docker Compose file to OpenShift:**
+**Convert your Compose file to OpenShift:**
 
 Run `kompose convert --provider=openshift` in the same directory as your `compose.yaml` file.
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -16,7 +16,7 @@ There are some projects out there known to use Kompose integrated in some form o
 
 ### Kompose UI by Jad Chamoun (ICANN) and Joe Haddad (Anghami)
 
-**Description:** "A web interface to convert Docker Compose files to Kubernetes YAML"
+**Description:** "A web interface to convert Compose files to Kubernetes YAML"
 
 **Link:** [https://github.com/JadCham/komposeui](https://github.com/JadCham/komposeui)
 
@@ -48,7 +48,7 @@ There are some projects out there known to use Kompose integrated in some form o
 
 **Description:** "Maven is one of the widely used build tools for Java applications. The Fabric8 Maven Plugin is a maven extension that simplifies the deployment of Java applications to Kubernetes or OpenShift clusters.
 The main task of this plugin is to build Docker images, generate Kubernetes or OpenShift resource descriptors and run/deploy the application on Kubernetes or OpenShift cluster.
-The plugin has a wide range of configuration options. Docker Compose is one of the options to bring up deployments on Kubernetes or OpenShift clusters.
+The plugin has a wide range of configuration options. Compose is one of the options to bring up deployments on Kubernetes or OpenShift clusters.
 Technically, Fabric8 Maven Plugin processes the external compose.yml file and generates Kubernetes or OpenShift resources via Kompose."
 
 **Links:**

--- a/docs/maven-example.md
+++ b/docs/maven-example.md
@@ -9,7 +9,7 @@ redirect_from:
 
 # Fabric8 Maven Plugin + Kompose:
 
-Let's deploy a Springboot Java application with Docker Compose file using Fabric8 Maven Plugin to Kubernetes or OpenShift.
+Let's deploy a Springboot Java application with Compose file using Fabric8 Maven Plugin to Kubernetes or OpenShift.
 
 ##### Requirements
 
@@ -46,7 +46,7 @@ $ mvn fabric8:install
 
 This command installs the `kompose` on the host.
 
-**4. Configure Fabric8 Maven Plugin to use a Docker Compose file**
+**4. Configure Fabric8 Maven Plugin to use a Compose file**
 
 ```bash
 <plugin>
@@ -66,7 +66,7 @@ This command installs the `kompose` on the host.
 </plugin>
 ```
 
-Add the `<configuration>` and `<executions>` sections to `pom.xml` as shown in above `pom.xml` snippet. Update the `<composeFile>` to provide the relative path of Docker Compose file from `pom.xml`
+Add the `<configuration>` and `<executions>` sections to `pom.xml` as shown in above `pom.xml` snippet. Update the `<composeFile>` to provide the relative path of Compose file from `pom.xml`
 
 **5. Deploy application on Kubernetes or OpenShift**
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -17,7 +17,7 @@ You can choose a targeted provider using global option `--provider`. If no provi
 
 ## Kompose Convert
 
-Kompose supports conversion of V1, V2, and V3 Docker Compose files into Kubernetes and OpenShift objects.
+Kompose supports conversion of V1, V2, and V3 Compose files into Kubernetes and OpenShift objects.
 
 ### Kubernetes
 
@@ -609,9 +609,9 @@ services:
 
 #### Warning about Deployment Config's
 
-If the Docker Compose file has a volume specified for a service, the Deployment (Kubernetes) or DeploymentConfig (OpenShift) strategy is changed to "Recreate" instead of "RollingUpdate" (default). This is done to avoid multiple instances of a service from accessing a volume at the same time.
+If the Compose file has a volume specified for a service, the Deployment (Kubernetes) or DeploymentConfig (OpenShift) strategy is changed to "Recreate" instead of "RollingUpdate" (default). This is done to avoid multiple instances of a service from accessing a volume at the same time.
 
-If the Docker Compose file has service name with `_` or `.` in it (eg.`web_service` or `web.service`), then it will be replaced by `-` and the service name will be renamed accordingly (eg.`web-service`). Kompose does this because "Kubernetes" doesn't allow `_` in object name.
+If the Compose file has service name with `_` or `.` in it (eg.`web_service` or `web.service`), then it will be replaced by `-` and the service name will be renamed accordingly (eg.`web-service`). Kompose does this because "Kubernetes" doesn't allow `_` in object name.
 
 Please note that changing service name might break some `compose` files.
 
@@ -621,7 +621,7 @@ To generate network policies, all you need is to use the `--generate-network-pol
 
 ## Build and push image
 
-If the Docker Compose file has `build` or `build:context, build:dockerfile` keys, build will run when `--build` specified.
+If the Compose file has `build` or `build:context, build:dockerfile` keys, build will run when `--build` specified.
 
 And Image will push to _docker.io_ (default) when `--push-image=true` specified.
 

--- a/index.md
+++ b/index.md
@@ -4,15 +4,15 @@ layout: default
 
 # Kubernetes + Compose = Kompose
 
-## A conversion tool to go from Docker Compose to Kubernetes
+## A conversion tool to go from Compose to Kubernetes
 
 ### What's Kompose?
 
-Kompose is a conversion tool for Docker Compose to container orchestrators such as Kubernetes (or OpenShift).
+Kompose is a conversion tool for Compose to container orchestrators such as Kubernetes (or OpenShift).
 
 Why do developers love it?
 
-- Simplify your development process with Docker Compose and then deploy your containers to a production cluster
+- Simplify your development process with Compose and then deploy your containers to a production cluster
 - Convert your `docker-compose.yaml` with one simple command `kompose convert`
 
 ### It's as simple as 1-2-3

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -250,7 +250,7 @@ func convertDockerLabel(dockerLabel string) (string, error) {
 	return "", errors.New(errMsg)
 }
 
-// Convert the Docker Compose volumes to []string (the old way)
+// Convert the Compose volumes to []string (the old way)
 // TODO: Check to see if it's a "bind" or "volume". Ignore for now.
 // TODO: Refactor it similar to loadPorts
 // See: https://docs.docker.com/compose/compose-file/#long-syntax-3
@@ -273,7 +273,7 @@ func loadVolumes(volumes []types.ServiceVolumeConfig) []string {
 	return volArray
 }
 
-// Convert Docker Compose ports to kobject.Ports
+// Convert Compose ports to kobject.Ports
 // expose ports will be treated as TCP ports
 func loadPorts(ports []types.ServicePortConfig, expose []string) []kobject.Ports {
 	komposePorts := []kobject.Ports{}

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1270,7 +1270,7 @@ func (k *Kubernetes) CreateWorkloadAndConfigMapObjects(name string, service kobj
 		replica = service.Replicas
 	}
 
-	// Check to see if Docker Compose v3 Deploy.Mode has been set to "global"
+	// Check to see if Compose v3 Deploy.Mode has been set to "global"
 	if service.DeployMode == "global" {
 		//default use daemonset
 		if opt.Controller == "" {

--- a/script/test/fixtures/buildargs/README.md
+++ b/script/test/fixtures/buildargs/README.md
@@ -1,4 +1,4 @@
-## Docker Compose Buildargs
+## Compose Buildargs
 
 ### Usage
 

--- a/script/test/fixtures/etherpad/README.md
+++ b/script/test/fixtures/etherpad/README.md
@@ -1,4 +1,4 @@
-## Docker Compose Etherpad
+## Compose Etherpad
 
 Etherpad and Mariadb
 


### PR DESCRIPTION
update references to just compose

#### What type of PR is this?

Change from Docker Compose references to just Compose

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

Compose is an open format and we should not say "Docker Compose".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/kubernetes/kompose/issues/1868

#### Special notes for your reviewer:

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
