### PR TITLE
fix: expose container to host only with labels

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -181,6 +181,7 @@ The currently supported options are:
 
 | Key                                                 | Value                                                                                |
 |-----------------------------------------------------|--------------------------------------------------------------------------------------|
+| kompose.controller.port.expose                      | defines whether to expose container to host or not (It has security concerns, not recommended) |
 | kompose.service.type                                | nodeport / clusterip / loadbalancer / headless                                       |
 | kompose.service.group                               | name to group the containers contained in a single pod                               |
 | kompose.service.expose                              | true / hostnames (separated by comma)                                                |

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -142,6 +142,7 @@ type ServiceConfig struct {
 	StopGracePeriod               string             `compose:"stop_grace_period"`
 	Build                         string             `compose:"build"`
 	BuildArgs                     map[string]*string `compose:"build-args"`
+	ExposeContainerToHost         bool               `compose:"kompose.controller.port.expose"`
 	ExposeService                 string             `compose:"kompose.service.expose"`
 	ExposeServicePath             string             `compose:"kompose.service.expose.path"`
 	BuildLabels                   map[string]string  `compose:"build-labels"`

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -759,6 +759,8 @@ func parseKomposeLabels(labels map[string]string, serviceConfig *kobject.Service
 			serviceConfig.ServiceExternalTrafficPolicy = serviceExternalTypeTrafficPolicy
 		case LabelSecurityContextFsGroup:
 			serviceConfig.FsGroup = cast.ToInt64(value)
+		case LabelExposeContainerToHost:
+			serviceConfig.ExposeContainerToHost = cast.ToBool(value)
 		case LabelServiceExpose:
 			serviceConfig.ExposeService = strings.Trim(value, " ,")
 		case LabelNodePortPort:

--- a/pkg/loader/compose/utils.go
+++ b/pkg/loader/compose/utils.go
@@ -104,6 +104,8 @@ const (
 	LabelHpaMemory = "kompose.hpa.memory"
 	// LabelNameOverride defines the override resource name
 	LabelNameOverride = "kompose.service.name_override"
+	// LabelExposeContainerToHost defines whether to expose container to host or not using hostPort
+	LabelExposeContainerToHost = "kompose.controller.port.expose"
 )
 
 // load environment variables from compose file

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -654,9 +654,12 @@ func ConfigPorts(service kobject.ServiceConfig) []api.ContainerPort {
 		}
 		containerPort := api.ContainerPort{
 			ContainerPort: port.ContainerPort,
-			HostIP:        port.HostIP,
-			HostPort:      port.HostPort,
 			Protocol:      api.Protocol(port.Protocol),
+		}
+
+		if service.ExposeContainerToHost {
+			containerPort.HostIP = port.HostIP
+			containerPort.HostPort = port.HostPort
 		}
 		ports = append(ports, containerPort)
 		exist[port.ID()] = true

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -88,10 +88,11 @@ func newKomposeObject() kobject.KomposeObject {
 
 func newKomposeObjectHostPortProtocolConfig() kobject.ServiceConfig {
 	return kobject.ServiceConfig{
-		Name:          "nginx",
-		ContainerName: "nginx",
-		Image:         "nginx",
-		Port:          []kobject.Ports{{HostPort: 80, Protocol: string(api.ProtocolTCP), ContainerPort: 80}},
+		Name:                  "nginx",
+		ContainerName:         "nginx",
+		Image:                 "nginx",
+		Port:                  []kobject.Ports{{HostPort: 80, Protocol: string(api.ProtocolTCP), ContainerPort: 80}},
+		ExposeContainerToHost: true,
 	}
 }
 

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -80,7 +80,6 @@ spec:
           name: web
           ports:
             - containerPort: 5000
-              hostPort: 5000
               protocol: TCP
           volumeMounts:
             - mountPath: /code

--- a/script/test/fixtures/change-in-volume/output-k8s.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s.yaml
@@ -80,7 +80,6 @@ spec:
           name: web
           ports:
             - containerPort: 5000
-              hostPort: 5000
               protocol: TCP
           volumeMounts:
             - mountPath: /code

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -107,7 +107,6 @@ spec:
           name: web
           ports:
             - containerPort: 5000
-              hostPort: 5000
               protocol: TCP
           volumeMounts:
             - mountPath: /code

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -107,7 +107,6 @@ spec:
           name: web
           ports:
             - containerPort: 5000
-              hostPort: 5000
               protocol: TCP
           volumeMounts:
             - mountPath: /code

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -37,7 +37,6 @@ spec:
           name: foo
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
@@ -51,7 +51,6 @@ spec:
           name: alpine
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 
@@ -78,7 +77,6 @@ spec:
           name: debian
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/compose-file-support/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-support/output-k8s.yaml
@@ -37,7 +37,6 @@ spec:
           name: web
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/configmap-file-configs/output-k8s-1.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-k8s-1.yaml
@@ -45,10 +45,8 @@ spec:
           name: busy
           ports:
             - containerPort: 8080
-              hostPort: 8081
               protocol: TCP
             - containerPort: 8025
-              hostPort: 8026
               protocol: TCP
           volumeMounts:
             - mountPath: /certs

--- a/script/test/fixtures/configmap-file-configs/output-k8s-2.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-k8s-2.yaml
@@ -45,10 +45,8 @@ spec:
           name: busy
           ports:
             - containerPort: 8080
-              hostPort: 8081
               protocol: TCP
             - containerPort: 8025
-              hostPort: 8026
               protocol: TCP
           volumeMounts:
             - mountPath: /certs

--- a/script/test/fixtures/configmap-file-configs/output-k8s-3.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-k8s-3.yaml
@@ -41,9 +41,7 @@ spec:
           name: busy
           ports:
             - containerPort: 8080
-              hostPort: 8081
               protocol: TCP
             - containerPort: 8025
-              hostPort: 8026
               protocol: TCP
       restartPolicy: Always

--- a/script/test/fixtures/configmap-file-configs/output-os-1.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-os-1.yaml
@@ -44,10 +44,8 @@ spec:
           name: busy
           ports:
             - containerPort: 8080
-              hostPort: 8081
               protocol: TCP
             - containerPort: 8025
-              hostPort: 8026
               protocol: TCP
           volumeMounts:
             - mountPath: /certs

--- a/script/test/fixtures/configmap-file-configs/output-os-2.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-os-2.yaml
@@ -44,10 +44,8 @@ spec:
           name: busy
           ports:
             - containerPort: 8080
-              hostPort: 8081
               protocol: TCP
             - containerPort: 8025
-              hostPort: 8026
               protocol: TCP
           volumeMounts:
             - mountPath: /certs

--- a/script/test/fixtures/configmap-file-configs/output-os-3.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-os-3.yaml
@@ -40,10 +40,8 @@ spec:
           name: busy
           ports:
             - containerPort: 8080
-              hostPort: 8081
               protocol: TCP
             - containerPort: 8025
-              hostPort: 8026
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/configmap-pod/output-k8s.yaml
+++ b/script/test/fixtures/configmap-pod/output-k8s.yaml
@@ -44,7 +44,6 @@ spec:
       name: redis
       ports:
         - containerPort: 6379
-          hostPort: 6379
           protocol: TCP
   restartPolicy: Never
 

--- a/script/test/fixtures/configmap-pod/output-os.yaml
+++ b/script/test/fixtures/configmap-pod/output-os.yaml
@@ -44,7 +44,6 @@ spec:
       name: redis
       ports:
         - containerPort: 6379
-          hostPort: 6379
           protocol: TCP
   restartPolicy: Never
 

--- a/script/test/fixtures/env-multiple/output-k8s.yaml
+++ b/script/test/fixtures/env-multiple/output-k8s.yaml
@@ -70,10 +70,8 @@ spec:
           name: another-namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
           resources: {}
       restartPolicy: Always
@@ -135,10 +133,8 @@ spec:
           name: namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
           resources: {}
       restartPolicy: Always

--- a/script/test/fixtures/env-multiple/output-os.yaml
+++ b/script/test/fixtures/env-multiple/output-os.yaml
@@ -92,10 +92,8 @@ spec:
           name: another-namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
           resources: {}
       restartPolicy: Always
@@ -169,10 +167,8 @@ spec:
           name: namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
           resources: {}
       restartPolicy: Always

--- a/script/test/fixtures/env/output-k8s.yaml
+++ b/script/test/fixtures/env/output-k8s.yaml
@@ -68,10 +68,8 @@ spec:
           name: another-namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
       restartPolicy: Always
 
@@ -123,10 +121,8 @@ spec:
           name: namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/env/output-os.yaml
+++ b/script/test/fixtures/env/output-os.yaml
@@ -78,10 +78,8 @@ spec:
           name: another-namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
       restartPolicy: Always
   test: false
@@ -149,10 +147,8 @@ spec:
           name: namenode
           ports:
             - containerPort: 50070
-              hostPort: 50070
               protocol: TCP
             - containerPort: 8020
-              hostPort: 8020
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/envvars-with-status/output-k8s.yaml
+++ b/script/test/fixtures/envvars-with-status/output-k8s.yaml
@@ -45,6 +45,5 @@ spec:
           name: app
           ports:
             - containerPort: 3000
-              hostPort: 3000
               protocol: TCP
       restartPolicy: Always

--- a/script/test/fixtures/envvars-with-status/output-os.yaml
+++ b/script/test/fixtures/envvars-with-status/output-os.yaml
@@ -44,7 +44,6 @@ spec:
           name: app
           ports:
             - containerPort: 3000
-              hostPort: 3000
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -77,7 +77,6 @@ spec:
           name: web
           ports:
             - containerPort: 5000
-              hostPort: 5000
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -104,7 +104,6 @@ spec:
           name: web
           ports:
             - containerPort: 5000
-              hostPort: 5000
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
@@ -41,7 +41,6 @@ spec:
           name: front-end
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
@@ -41,7 +41,6 @@ spec:
           name: front-end
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -40,7 +40,6 @@ spec:
           name: front-end
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -40,7 +40,6 @@ spec:
           name: front-end
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/host-port-protocol/compose.yaml
+++ b/script/test/fixtures/host-port-protocol/compose.yaml
@@ -2,6 +2,8 @@ version: "3.3"
 
 services:
   nginx:
+    labels:
+      kompose.container.kompose.controller.port.expose: true
     ports:
       - target: 80
         published: 80

--- a/script/test/fixtures/host-port-protocol/output-k8s.yaml
+++ b/script/test/fixtures/host-port-protocol/output-k8s.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     io.kompose.service: nginx
 
-
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,8 +36,6 @@ spec:
           name: nginx
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
-
 

--- a/script/test/fixtures/host-port-protocol/output-os.yaml
+++ b/script/test/fixtures/host-port-protocol/output-os.yaml
@@ -35,7 +35,6 @@ spec:
           name: nginx
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/namespace/output-k8s.yaml
+++ b/script/test/fixtures/namespace/output-k8s.yaml
@@ -47,7 +47,6 @@ spec:
           name: web
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/namespace/output-os.yaml
+++ b/script/test/fixtures/namespace/output-os.yaml
@@ -44,7 +44,6 @@ spec:
           name: web
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/network-mode-service/output-k8s.yaml
+++ b/script/test/fixtures/network-mode-service/output-k8s.yaml
@@ -39,7 +39,6 @@ spec:
           name: threats-client
           ports:
             - containerPort: 8080
-              hostPort: 8080
               protocol: TCP
         - args:
             - sleep

--- a/script/test/fixtures/network-policies/output-k8s.yaml
+++ b/script/test/fixtures/network-policies/output-k8s.yaml
@@ -37,7 +37,6 @@ spec:
           name: nginx
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/read-only/output-k8s.yaml
+++ b/script/test/fixtures/read-only/output-k8s.yaml
@@ -37,7 +37,6 @@ spec:
           name: test
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
           securityContext:
             readOnlyRootFilesystem: true

--- a/script/test/fixtures/read-only/output-os.yaml
+++ b/script/test/fixtures/read-only/output-os.yaml
@@ -35,7 +35,6 @@ spec:
           name: test
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
           securityContext:
             readOnlyRootFilesystem: true

--- a/script/test/fixtures/resources-lowercase/output-k8s.yaml
+++ b/script/test/fixtures/resources-lowercase/output-k8s.yaml
@@ -36,7 +36,6 @@ spec:
           name: nginx
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/resources-lowercase/output-os.yaml
+++ b/script/test/fixtures/resources-lowercase/output-os.yaml
@@ -35,7 +35,6 @@ spec:
           name: nginx
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
   test: false

--- a/script/test/fixtures/service-group/output-k8s.yaml
+++ b/script/test/fixtures/service-group/output-k8s.yaml
@@ -48,7 +48,6 @@ spec:
           name: librenms
           ports:
             - containerPort: 8000
-              hostPort: 8000
               protocol: TCP
           volumeMounts:
             - mountPath: /data

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -39,7 +39,6 @@ spec:
           name: front-end
           ports:
             - containerPort: 80
-              hostPort: 80
               protocol: TCP
       restartPolicy: Always
 

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -67,7 +67,6 @@ spec:
           name: db
           ports:
             - containerPort: 3306
-              hostPort: 3306
               protocol: TCP
           volumeMounts:
             - mountPath: /var/lib/mysql
@@ -118,7 +117,6 @@ spec:
           name: wordpress
           ports:
             - containerPort: 80
-              hostPort: 8000
               protocol: TCP
           volumeMounts:
             - mountPath: /var/www/html

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -63,7 +63,6 @@ spec:
           name: db
           ports:
             - containerPort: 3306
-              hostPort: 3306
               protocol: TCP
           volumeMounts:
             - mountPath: /var/lib/mysql
@@ -114,7 +113,6 @@ spec:
           name: db
           ports:
             - containerPort: 3306
-              hostPort: 3306
               protocol: TCP
           volumeMounts:
             - mountPath: /var/lib/mysql
@@ -185,7 +183,6 @@ spec:
           name: wordpress
           ports:
             - containerPort: 80
-              hostPort: 8000
               protocol: TCP
           volumeMounts:
             - mountPath: /var/www/html
@@ -236,7 +233,6 @@ spec:
           name: wordpress
           ports:
             - containerPort: 80
-              hostPort: 8000
               protocol: TCP
           volumeMounts:
             - mountPath: /var/www/html

--- a/script/test/fixtures/v2/output-k8s.yaml
+++ b/script/test/fixtures/v2/output-k8s.yaml
@@ -17,9 +17,6 @@ spec:
     - name: "3000"
       port: 3000
       targetPort: 3000
-    - name: 3000-tcp
-      port: 3000
-      targetPort: 3000
     - name: "3001"
       port: 3001
       targetPort: 3001
@@ -90,8 +87,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: loadbalancer
   labels:
     io.kompose.service: redis-tcp
   name: redis-tcp
@@ -108,8 +103,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: loadbalancer
   labels:
     io.kompose.service: redis-udp
   name: redis-udp
@@ -156,64 +149,36 @@ spec:
         - containerPort: 3005
           protocol: TCP
         - containerPort: 8000
-          hostPort: 8000
           protocol: TCP
         - containerPort: 8080
-          hostPort: 9090
           protocol: TCP
         - containerPort: 8081
-          hostPort: 9091
           protocol: TCP
         - containerPort: 22
-          hostPort: 49100
           protocol: TCP
         - containerPort: 8001
-          hostIP: 127.0.0.1
-          hostPort: 8001
           protocol: TCP
         - containerPort: 5000
-          hostIP: 127.0.0.1
-          hostPort: 5000
           protocol: TCP
         - containerPort: 5001
-          hostIP: 127.0.0.1
-          hostPort: 5001
           protocol: TCP
         - containerPort: 5002
-          hostIP: 127.0.0.1
-          hostPort: 5002
           protocol: TCP
         - containerPort: 5003
-          hostIP: 127.0.0.1
-          hostPort: 5003
           protocol: TCP
         - containerPort: 5004
-          hostIP: 127.0.0.1
-          hostPort: 5004
           protocol: TCP
         - containerPort: 5005
-          hostIP: 127.0.0.1
-          hostPort: 5005
           protocol: TCP
         - containerPort: 5006
-          hostIP: 127.0.0.1
-          hostPort: 5006
           protocol: TCP
         - containerPort: 5007
-          hostIP: 127.0.0.1
-          hostPort: 5007
           protocol: TCP
         - containerPort: 5008
-          hostIP: 127.0.0.1
-          hostPort: 5008
           protocol: TCP
         - containerPort: 5009
-          hostIP: 127.0.0.1
-          hostPort: 5009
           protocol: TCP
         - containerPort: 5010
-          hostIP: 127.0.0.1
-          hostPort: 5010
           protocol: TCP
       resources:
         limits:
@@ -227,8 +192,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.type: loadbalancer
   labels:
     io.kompose.service: redis
   name: redis
@@ -239,8 +202,6 @@ spec:
       io.kompose.service: redis
   template:
     metadata:
-      annotations:
-        kompose.service.type: loadbalancer
       labels:
         io.kompose.network/v2-default: "true"
         io.kompose.service: redis
@@ -252,7 +213,6 @@ spec:
             - containerPort: 6379
               protocol: TCP
             - containerPort: 1235
-              hostPort: 1234
               protocol: UDP
           resources:
             limits:

--- a/script/test/fixtures/v2/output-os.yaml
+++ b/script/test/fixtures/v2/output-os.yaml
@@ -17,9 +17,6 @@ spec:
     - name: "3000"
       port: 3000
       targetPort: 3000
-    - name: 3000-tcp
-      port: 3000
-      targetPort: 3000
     - name: "3001"
       port: 3001
       targetPort: 3001
@@ -90,8 +87,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: loadbalancer
   labels:
     io.kompose.service: redis-tcp
   name: redis-tcp
@@ -108,8 +103,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: loadbalancer
   labels:
     io.kompose.service: redis-udp
   name: redis-udp
@@ -156,64 +149,36 @@ spec:
         - containerPort: 3005
           protocol: TCP
         - containerPort: 8000
-          hostPort: 8000
           protocol: TCP
         - containerPort: 8080
-          hostPort: 9090
           protocol: TCP
         - containerPort: 8081
-          hostPort: 9091
           protocol: TCP
         - containerPort: 22
-          hostPort: 49100
           protocol: TCP
         - containerPort: 8001
-          hostIP: 127.0.0.1
-          hostPort: 8001
           protocol: TCP
         - containerPort: 5000
-          hostIP: 127.0.0.1
-          hostPort: 5000
           protocol: TCP
         - containerPort: 5001
-          hostIP: 127.0.0.1
-          hostPort: 5001
           protocol: TCP
         - containerPort: 5002
-          hostIP: 127.0.0.1
-          hostPort: 5002
           protocol: TCP
         - containerPort: 5003
-          hostIP: 127.0.0.1
-          hostPort: 5003
           protocol: TCP
         - containerPort: 5004
-          hostIP: 127.0.0.1
-          hostPort: 5004
           protocol: TCP
         - containerPort: 5005
-          hostIP: 127.0.0.1
-          hostPort: 5005
           protocol: TCP
         - containerPort: 5006
-          hostIP: 127.0.0.1
-          hostPort: 5006
           protocol: TCP
         - containerPort: 5007
-          hostIP: 127.0.0.1
-          hostPort: 5007
           protocol: TCP
         - containerPort: 5008
-          hostIP: 127.0.0.1
-          hostPort: 5008
           protocol: TCP
         - containerPort: 5009
-          hostIP: 127.0.0.1
-          hostPort: 5009
           protocol: TCP
         - containerPort: 5010
-          hostIP: 127.0.0.1
-          hostPort: 5010
           protocol: TCP
       resources:
         limits:
@@ -227,8 +192,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.type: loadbalancer
   labels:
     io.kompose.service: redis
   name: redis
@@ -249,7 +212,6 @@ spec:
             - containerPort: 6379
               protocol: TCP
             - containerPort: 1235
-              hostPort: 1234
               protocol: UDP
           resources:
             limits:

--- a/script/test/fixtures/v3.0/output-k8s.yaml
+++ b/script/test/fixtures/v3.0/output-k8s.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: headless
   labels:
     io.kompose.service: redis
   name: redis
@@ -49,8 +47,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.service.type: headless
   labels:
     io.kompose.service: redis
   name: redis
@@ -61,8 +57,6 @@ spec:
       io.kompose.service: redis
   template:
     metadata:
-      annotations:
-        kompose.service.type: headless
       labels:
         io.kompose.network/v30-default: "true"
         io.kompose.service: redis

--- a/script/test/fixtures/v3.0/output-os.yaml
+++ b/script/test/fixtures/v3.0/output-os.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.service.type: headless
   labels:
     io.kompose.service: redis
   name: redis
@@ -27,8 +25,6 @@ spec:
   replicas: 1
   selector:
     io.kompose.service: foo
-  strategy:
-    resources: {}
   template:
     metadata:
       labels:
@@ -79,8 +75,6 @@ spec:
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  annotations:
-    kompose.service.type: headless
   labels:
     io.kompose.service: redis
   name: redis


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind cleanup

#### What this PR does / why we need it:
Only expose container to host when we specify the label

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1878 

#### Special notes for your reviewer:
