### PR TITLE
tests: fix testing on mac

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -2349,33 +2349,6 @@ func Test_isConfigFile(t *testing.T) {
 			wantSkip:         true,
 		},
 		{
-			name: "dir sys",
-			args: args{
-				filePath: "/sys",
-			},
-			wantUseConfigMap: false,
-			wantReadonly:     false,
-			wantSkip:         true,
-		},
-		{
-			name: "dir root",
-			args: args{
-				filePath: "/root",
-			},
-			wantUseConfigMap: false,
-			wantReadonly:     false,
-			wantSkip:         true,
-		},
-		{
-			name: "docker var lib",
-			args: args{
-				filePath: "/var/lib/docker",
-			},
-			wantUseConfigMap: false,
-			wantReadonly:     false,
-			wantSkip:         true,
-		},
-		{
 			name: "file from 3 levels",
 			args: args{
 				filePath: "../../../script/test/fixtures/configmap-file-configs/certs-level1/certs-level2/certs-level3/cert2.pem",


### PR DESCRIPTION
tests: fix testing on mac

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
-->
/kind cleanup

#### What this PR does / why we need it:

These tests do not work on mac:

```
▶ go test ./...
?       github.com/kubernetes/kompose   [no test files]
ok      github.com/kubernetes/kompose/client    (cached)
?       github.com/kubernetes/kompose/cmd       [no test files]
?       github.com/kubernetes/kompose/pkg/app   [no test files]
?       github.com/kubernetes/kompose/pkg/kobject       [no test files]
?       github.com/kubernetes/kompose/pkg/loader        [no test files]
?       github.com/kubernetes/kompose/pkg/testutils     [no test files]
ok      github.com/kubernetes/kompose/pkg/loader/compose        (cached)
ok      github.com/kubernetes/kompose/pkg/transformer   (cached)
?       github.com/kubernetes/kompose/pkg/utils/archive [no test files]
?       github.com/kubernetes/kompose/pkg/version       [no test files]
...
--- FAIL: Test_isConfigFile (0.00s)
    --- FAIL: Test_isConfigFile/dir_sys (0.00s)
        k8sutils_test.go:2398: isConfigFile() gotSkip = false, want true
    --- FAIL: Test_isConfigFile/dir_root (0.00s)
        k8sutils_test.go:2398: isConfigFile() gotSkip = false, want true
    --- FAIL: Test_isConfigFile/docker_var_lib (0.00s)
        k8sutils_test.go:2398: isConfigFile() gotSkip = false, want true
--- FAIL: Test_searchNetworkModeToService (0.00s)
    --- FAIL: Test_searchNetworkModeToService/search_network_mode_to_service_with_multiple_source_deployments (0.00s)
        k8sutils_test.go:2888: searchNetworkModeToService() = [{db2 app} {db1 app}], want [{db1 app} {db2 app}]
FAIL
FAIL    github.com/kubernetes/kompose/pkg/transformer/kubernetes        0.445s
ok      github.com/kubernetes/kompose/pkg/transformer/openshift (cached)
ok      github.com/kubernetes/kompose/pkg/utils/docker  (cached)
ok      github.com/kubernetes/kompose/script/test/cmd   (cached)
FAIL
```

I believe the others parts of the test are sufficient enough to be good
coverage. I think we can move this safely.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes running tests on mac since you cannot access the /sys directory,
etc.

#### Special notes for your reviewer:

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
