### PR TITLE
cleanup: removes uneeded annotation when not using network policy

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1600,7 +1600,7 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 					podSpec.Append(ServiceAccountName(serviceAccountName))
 				}
 
-				err = k.UpdateKubernetesObjectsMultipleContainers(groupName, service, &objects, podSpec)
+				err = k.UpdateKubernetesObjectsMultipleContainers(groupName, service, &objects, podSpec, opt)
 				if err != nil {
 					return nil, errors.Wrap(err, "Error transforming Kubernetes objects")
 				}

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -50,7 +50,6 @@ func newServiceConfig() kobject.ServiceConfig {
 		WorkingDir:      "dir",
 		Args:            []string{"arg1", "arg2"},
 		VolList:         []string{"/tmp/volume"},
-		Network:         []string{"network1", "network2"}, // supported
 		Labels:          nil,
 		FsGroup:         1001,
 		Annotations:     map[string]string{"abc": "def"},

--- a/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s-empty-vols-template.yaml
@@ -44,7 +44,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
     spec:
       containers:
@@ -69,7 +68,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/change-in-volume/output-k8s.yaml
+++ b/script/test/fixtures/change-in-volume/output-k8s.yaml
@@ -44,7 +44,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
     spec:
       containers:
@@ -69,7 +68,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
+++ b/script/test/fixtures/change-in-volume/output-os-empty-vols-template.yaml
@@ -43,7 +43,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
     spec:
       containers:
@@ -96,7 +95,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/change-in-volume/output-os.yaml
+++ b/script/test/fixtures/change-in-volume/output-os.yaml
@@ -43,7 +43,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: redis
     spec:
       containers:
@@ -96,7 +95,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/change-in-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-interpolation/output-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/compose-env-interpolation-default: "true"
         io.kompose.service: foo
     spec:
       containers:

--- a/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-env-variable/output-k8s.yaml
@@ -43,7 +43,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/compose-file-env-variable-default: "true"
         io.kompose.service: alpine
     spec:
       containers:
@@ -69,7 +68,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/compose-file-env-variable-default: "true"
         io.kompose.service: debian
     spec:
       containers:

--- a/script/test/fixtures/compose-file-support/output-k8s.yaml
+++ b/script/test/fixtures/compose-file-support/output-k8s.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/compose-file-support-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/configmap-file-configs/output-k8s-1.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-k8s-1.yaml
@@ -33,7 +33,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-file-configs-default: "true"
         io.kompose.service: busy
     spec:
       containers:

--- a/script/test/fixtures/configmap-file-configs/output-k8s-2.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-k8s-2.yaml
@@ -33,7 +33,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-file-configs-default: "true"
         io.kompose.service: busy
     spec:
       containers:

--- a/script/test/fixtures/configmap-file-configs/output-k8s-3.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-k8s-3.yaml
@@ -33,7 +33,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-file-configs-default: "true"
         io.kompose.service: busy
     spec:
       containers:

--- a/script/test/fixtures/configmap-file-configs/output-os-1.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-os-1.yaml
@@ -32,7 +32,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-file-configs-default: "true"
         io.kompose.service: busy
     spec:
       containers:

--- a/script/test/fixtures/configmap-file-configs/output-os-2.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-os-2.yaml
@@ -32,7 +32,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-file-configs-default: "true"
         io.kompose.service: busy
     spec:
       containers:

--- a/script/test/fixtures/configmap-file-configs/output-os-3.yaml
+++ b/script/test/fixtures/configmap-file-configs/output-os-3.yaml
@@ -32,7 +32,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-file-configs-default: "true"
         io.kompose.service: busy
     spec:
       containers:

--- a/script/test/fixtures/configmap-pod/output-k8s.yaml
+++ b/script/test/fixtures/configmap-pod/output-k8s.yaml
@@ -19,7 +19,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    io.kompose.network/configmap-pod-default: "true"
     io.kompose.service: redis
   name: redis
 spec:

--- a/script/test/fixtures/configmap-pod/output-os.yaml
+++ b/script/test/fixtures/configmap-pod/output-os.yaml
@@ -19,7 +19,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    io.kompose.network/configmap-pod-default: "true"
     io.kompose.service: redis
   name: redis
 spec:

--- a/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s-withlabel.yaml
@@ -15,7 +15,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -63,7 +62,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/configmap-volume/output-k8s.yaml
+++ b/script/test/fixtures/configmap-volume/output-k8s.yaml
@@ -15,7 +15,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -64,7 +63,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/output-os-withlabel.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -90,7 +89,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/configmap-volume/output-os.yaml
+++ b/script/test/fixtures/configmap-volume/output-os.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -91,7 +90,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/configmap-volume-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/cronjob/output-k8s.yaml
+++ b/script/test/fixtures/cronjob/output-k8s.yaml
@@ -13,7 +13,6 @@ spec:
       template:
         metadata:
           labels:
-            io.kompose.network/cronjob-default: "true"
             io.kompose.service: challenge
         spec:
           containers:

--- a/script/test/fixtures/cronjob/output-os.yaml
+++ b/script/test/fixtures/cronjob/output-os.yaml
@@ -13,7 +13,6 @@ spec:
       template:
         metadata:
           labels:
-            io.kompose.network/cronjob-default: "true"
             io.kompose.service: challenge
         spec:
           containers:

--- a/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/placement-default: "true"
         io.kompose.service: redis
     spec:
       affinity:

--- a/script/test/fixtures/deploy/placement/output-placement-os.yaml
+++ b/script/test/fixtures/deploy/placement/output-placement-os.yaml
@@ -27,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/placement-default: "true"
         io.kompose.service: redis
     spec:
       affinity:

--- a/script/test/fixtures/env-multiple/output-k8s.yaml
+++ b/script/test/fixtures/env-multiple/output-k8s.yaml
@@ -56,7 +56,6 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: another-namenode
     spec:
       containers:
@@ -117,7 +116,6 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: namenode
     spec:
       containers:

--- a/script/test/fixtures/env-multiple/output-os.yaml
+++ b/script/test/fixtures/env-multiple/output-os.yaml
@@ -78,7 +78,6 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: another-namenode
     spec:
       containers:
@@ -151,7 +150,6 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: namenode
     spec:
       containers:

--- a/script/test/fixtures/env/output-k8s.yaml
+++ b/script/test/fixtures/env/output-k8s.yaml
@@ -49,7 +49,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: another-namenode
     spec:
       containers:
@@ -100,7 +99,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: namenode
     spec:
       containers:

--- a/script/test/fixtures/env/output-os.yaml
+++ b/script/test/fixtures/env/output-os.yaml
@@ -59,7 +59,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: another-namenode
     spec:
       containers:
@@ -126,7 +125,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/env-default: "true"
         io.kompose.service: namenode
     spec:
       containers:

--- a/script/test/fixtures/envvars-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-k8s.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/envvars-interpolation-default: "true"
         io.kompose.service: myservice
     spec:
       containers:

--- a/script/test/fixtures/envvars-interpolation/output-os.yaml
+++ b/script/test/fixtures/envvars-interpolation/output-os.yaml
@@ -12,7 +12,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/envvars-interpolation-default: "true"
         io.kompose.service: myservice
     spec:
       containers:

--- a/script/test/fixtures/envvars-with-status/output-k8s.yaml
+++ b/script/test/fixtures/envvars-with-status/output-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/envvars-with-status-default: "true"
         io.kompose.service: app
     spec:
       containers:

--- a/script/test/fixtures/envvars-with-status/output-os.yaml
+++ b/script/test/fixtures/envvars-with-status/output-os.yaml
@@ -27,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/envvars-with-status-default: "true"
         io.kompose.service: app
     spec:
       containers:

--- a/script/test/fixtures/expose/output-k8s.yaml
+++ b/script/test/fixtures/expose/output-k8s.yaml
@@ -43,7 +43,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/expose-default: "true"
         io.kompose.service: redis
     spec:
       containers:
@@ -69,7 +68,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/expose-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/expose/output-os.yaml
+++ b/script/test/fixtures/expose/output-os.yaml
@@ -42,7 +42,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/expose-default: "true"
         io.kompose.service: redis
     spec:
       containers:
@@ -96,7 +95,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/expose-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v1.yaml
@@ -30,7 +30,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
     spec:
       containers:

--- a/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-k8s-v2.yaml
@@ -30,7 +30,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
     spec:
       containers:

--- a/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v1.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
     spec:
       containers:

--- a/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/output-os-v2.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/external-traffic-policy-default: "true"
         io.kompose.service: front-end
     spec:
       containers:

--- a/script/test/fixtures/fsgroup/output-k8s.yaml
+++ b/script/test/fixtures/fsgroup/output-k8s.yaml
@@ -15,7 +15,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/fsgroup-default: "true"
         io.kompose.service: pgadmin
     spec:
       containers:

--- a/script/test/fixtures/fsgroup/output-os.yaml
+++ b/script/test/fixtures/fsgroup/output-os.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/fsgroup-default: "true"
         io.kompose.service: pgadmin
     spec:
       containers:

--- a/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-k8s.yaml
@@ -73,7 +73,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mongo
     spec:
       containers:
@@ -111,7 +110,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mysql
     spec:
       containers:
@@ -149,7 +147,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: postgresql
     spec:
       containers:
@@ -189,7 +186,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: redis
     spec:
       containers:

--- a/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
+++ b/script/test/fixtures/healthcheck/output-healthcheck-os.yaml
@@ -72,7 +72,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mongo
     spec:
       containers:
@@ -138,7 +137,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: mysql
     spec:
       containers:
@@ -204,7 +202,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: postgresql
     spec:
       containers:
@@ -272,7 +269,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/healthcheck-default: "true"
         io.kompose.service: redis
     spec:
       containers:

--- a/script/test/fixtures/host-port-protocol/output-k8s.yaml
+++ b/script/test/fixtures/host-port-protocol/output-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/host-port-protocol-default: "true"
         io.kompose.service: nginx
     spec:
       containers:

--- a/script/test/fixtures/host-port-protocol/output-os.yaml
+++ b/script/test/fixtures/host-port-protocol/output-os.yaml
@@ -27,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/host-port-protocol-default: "true"
         io.kompose.service: nginx
     spec:
       containers:

--- a/script/test/fixtures/hpa/output-k8s.yaml
+++ b/script/test/fixtures/hpa/output-k8s.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/hpa-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/initcontainer/output-k8s.yaml
+++ b/script/test/fixtures/initcontainer/output-k8s.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/initcontainer-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/multiple-files/output-k8s.yaml
+++ b/script/test/fixtures/multiple-files/output-k8s.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-files-default: "true"
         io.kompose.service: bar
     spec:
       containers:
@@ -37,7 +36,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-files-default: "true"
         io.kompose.service: foo
     spec:
       containers:

--- a/script/test/fixtures/multiple-files/output-os.yaml
+++ b/script/test/fixtures/multiple-files/output-os.yaml
@@ -12,7 +12,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-files-default: "true"
         io.kompose.service: bar
     spec:
       containers:
@@ -63,7 +62,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-files-default: "true"
         io.kompose.service: foo
     spec:
       containers:

--- a/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-k8s.yaml
@@ -15,7 +15,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -61,7 +60,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/multiple-type-volumes/output-os.yaml
+++ b/script/test/fixtures/multiple-type-volumes/output-os.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -88,7 +87,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/multiple-type-volumes-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/namespace/output-k8s.yaml
+++ b/script/test/fixtures/namespace/output-k8s.yaml
@@ -39,7 +39,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/namespace-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/namespace/output-os.yaml
+++ b/script/test/fixtures/namespace/output-os.yaml
@@ -36,7 +36,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/namespace-default: "true"
         io.kompose.service: web
     spec:
       containers:

--- a/script/test/fixtures/network-mode-service/output-k8s.yaml
+++ b/script/test/fixtures/network-mode-service/output-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/network-mode-service-default: "true"
         io.kompose.service: client
     spec:
       containers:

--- a/script/test/fixtures/read-only/output-k8s.yaml
+++ b/script/test/fixtures/read-only/output-k8s.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/read-only-default: "true"
         io.kompose.service: test
     spec:
       containers:

--- a/script/test/fixtures/read-only/output-os.yaml
+++ b/script/test/fixtures/read-only/output-os.yaml
@@ -27,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/read-only-default: "true"
         io.kompose.service: test
     spec:
       containers:

--- a/script/test/fixtures/resources-lowercase/output-k8s.yaml
+++ b/script/test/fixtures/resources-lowercase/output-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/resources-lowercase-default: "true"
         io.kompose.service: nginx
     spec:
       containers:

--- a/script/test/fixtures/resources-lowercase/output-os.yaml
+++ b/script/test/fixtures/resources-lowercase/output-os.yaml
@@ -27,7 +27,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/resources-lowercase-default: "true"
         io.kompose.service: nginx
     spec:
       containers:

--- a/script/test/fixtures/service-group/output-k8s.yaml
+++ b/script/test/fixtures/service-group/output-k8s.yaml
@@ -31,7 +31,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/service-group-default: "true"
         io.kompose.service: librenms-dispatcher
     spec:
       containers:

--- a/script/test/fixtures/single-file-output/output-k8s.yaml
+++ b/script/test/fixtures/single-file-output/output-k8s.yaml
@@ -28,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/single-file-output-default: "true"
         io.kompose.service: front-end
     spec:
       containers:

--- a/script/test/fixtures/statefulset/output-k8s.yaml
+++ b/script/test/fixtures/statefulset/output-k8s.yaml
@@ -50,7 +50,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/statefulset-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -100,7 +99,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/statefulset-default: "true"
         io.kompose.service: wordpress
     spec:
       containers:

--- a/script/test/fixtures/statefulset/output-os.yaml
+++ b/script/test/fixtures/statefulset/output-os.yaml
@@ -46,7 +46,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/statefulset-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -96,7 +95,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/statefulset-default: "true"
         io.kompose.service: db
     spec:
       containers:
@@ -166,7 +164,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/statefulset-default: "true"
         io.kompose.service: wordpress
     spec:
       containers:
@@ -216,7 +213,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/statefulset-default: "true"
         io.kompose.service: wordpress
     spec:
       containers:

--- a/script/test/fixtures/v2/output-k8s.yaml
+++ b/script/test/fixtures/v2/output-k8s.yaml
@@ -121,7 +121,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    io.kompose.network/v2-default: "true"
     io.kompose.service: foo
   name: foo
 spec:
@@ -203,7 +202,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/v2-default: "true"
         io.kompose.service: redis
     spec:
       containers:

--- a/script/test/fixtures/v2/output-os.yaml
+++ b/script/test/fixtures/v2/output-os.yaml
@@ -121,7 +121,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    io.kompose.network/v2-default: "true"
     io.kompose.service: foo
   name: foo
 spec:
@@ -202,7 +201,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/v2-default: "true"
         io.kompose.service: redis
     spec:
       containers:

--- a/script/test/fixtures/v3.0/output-k8s.yaml
+++ b/script/test/fixtures/v3.0/output-k8s.yaml
@@ -29,9 +29,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/app-network: "true"
-        io.kompose.network/v30-normalized-network: "true"
-        io.kompose.network/web-network: "true"
         io.kompose.service: foo
     spec:
       containers:
@@ -58,7 +55,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/v30-default: "true"
         io.kompose.service: redis
     spec:
       containers:

--- a/script/test/fixtures/v3.0/output-os.yaml
+++ b/script/test/fixtures/v3.0/output-os.yaml
@@ -28,9 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/app-network: "true"
-        io.kompose.network/v30-normalized-network: "true"
-        io.kompose.network/web-network: "true"
         io.kompose.service: foo
     spec:
       containers:
@@ -85,7 +82,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/v30-default: "true"
         io.kompose.service: redis
     spec:
       containers:

--- a/script/test/fixtures/vols-subpath/output-k8s.yaml
+++ b/script/test/fixtures/vols-subpath/output-k8s.yaml
@@ -15,7 +15,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/vols-subpath-default: "true"
         io.kompose.service: postgres
     spec:
       containers:

--- a/script/test/fixtures/vols-subpath/output-os.yaml
+++ b/script/test/fixtures/vols-subpath/output-os.yaml
@@ -14,7 +14,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/vols-subpath-default: "true"
         io.kompose.service: postgres
     spec:
       containers:

--- a/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-k8s.yaml
@@ -30,7 +30,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/windows-default: "true"
         io.kompose.service: db
     spec:
       containers:

--- a/script/test/fixtures/volume-mounts/windows/output-os.yaml
+++ b/script/test/fixtures/volume-mounts/windows/output-os.yaml
@@ -30,7 +30,6 @@ spec:
   template:
     metadata:
       labels:
-        io.kompose.network/windows-default: "true"
         io.kompose.service: db
     spec:
       containers:


### PR DESCRIPTION
cleanup: removes uneeded annotation when not using network policy

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
-->

/kind cleanup

#### What this PR does / why we need it:

Removes the network policy annotation which is not needed (we are not
generating network policy)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes/kompose/issues/1759

#### Special notes for your reviewer:
