### PR TITLE
[completion] Add header #compdef

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -85,6 +85,8 @@ in order to generate ZSH completion support.
 */
 func runCompletionZsh(out io.Writer, kompose *cobra.Command) error {
 	zshInitialization := `
+#compdef kompose
+
 __kompose_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:

Generation of zsh completion misses header `#compdef kompose` as updated in reference:
https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/completion/completion.go#L174

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A

#### Special notes for your reviewer:

Not familiar with Go, but looks confident about 🤗 

Since the completion is not "native" but converted from `bash`, the directive `compdef <function> <command>` looks not mandatory (this is the second line to append when completion is zsh-native)