### PR TITLE
feature: support UID:GID in the user key

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"strconv"
 	"testing"
 
 	"github.com/kubernetes/kompose/pkg/kobject"
@@ -208,7 +207,7 @@ func TestCreateServiceWithServiceUser(t *testing.T) {
 		Expose:        []string{"expose"},   // not supported
 		Privileged:    true,
 		Restart:       "always",
-		User:          "1234",
+		User:          "1234:5678",
 	}
 
 	komposeObject := kobject.KomposeObject{
@@ -224,8 +223,9 @@ func TestCreateServiceWithServiceUser(t *testing.T) {
 	for _, obj := range objects {
 		if deploy, ok := obj.(*appsv1.Deployment); ok {
 			uid := *deploy.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser
-			if strconv.FormatInt(uid, 10) != service.User {
-				t.Errorf("User in ServiceConfig is not matching user in PodSpec")
+			gid := *deploy.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup
+			if fmt.Sprintf("%d:%d", uid, gid) != service.User {
+				t.Errorf("User and group in ServiceConfig is not matching user in PodSpec")
 			}
 		}
 	}

--- a/pkg/transformer/kubernetes/podspec.go
+++ b/pkg/transformer/kubernetes/podspec.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"reflect"
 	"strconv"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/kubernetes/kompose/pkg/kobject"
@@ -143,11 +144,30 @@ func SecurityContext(name string, service kobject.ServiceConfig) PodSpecOption {
 			securityContext.Privileged = &service.Privileged
 		}
 		if service.User != "" {
-			uid, err := strconv.ParseInt(service.User, 10, 64)
-			if err != nil {
-				log.Warn("Ignoring user directive. User to be specified as a UID (numeric).")
-			} else {
-				securityContext.RunAsUser = &uid
+			switch userparts := strings.Split(service.User, ":"); len(userparts) {
+			default:
+				log.Warn("Ignoring ill-formed user directive. Must be in format UID or UID:GID.")
+			case 1:
+				uid, err := strconv.ParseInt(userparts[0], 10, 64)
+				if err != nil {
+					log.Warn("Ignoring user directive. User to be specified as a UID (numeric).")
+				} else {
+					securityContext.RunAsUser = &uid
+				}
+			case 2:
+				uid, err := strconv.ParseInt(userparts[0], 10, 64)
+				if err != nil {
+					log.Warn("Ignoring user name in user directive. User to be specified as a UID (numeric).")
+				} else {
+					securityContext.RunAsUser = &uid
+				}
+
+				gid, err := strconv.ParseInt(userparts[1], 10, 64)
+				if err != nil {
+					log.Warn("Ignoring group name in user directive. Group to be specified as a GID (numeric).")
+				} else {
+					securityContext.RunAsGroup = &gid
+				}
 			}
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

With this PR, Kompose can convert `UID:GID` to both `RunAsUser` and `RunAsGroup`. Previously, it cannot understand the `:GID` part.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

I modified the existing test case to check `uid:gid`. It does not check the simpler case `uid`. Also, one of the file does not seem to have existing tests (?).