### PR TITLE
feat(deploy): support ephemeral storage requests limits labels

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -811,7 +811,7 @@ func KomposeObjectToServiceConfigGroupMapping(komposeObject *kobject.KomposeObje
 // TranslatePodResource config pod resources
 func TranslatePodResource(service *kobject.ServiceConfig, template *api.PodTemplateSpec) {
 	// Configure the resource limits
-	if service.MemLimit != 0 || service.CPULimit != 0 || service.DeployLabels["limits.ephemeral-storage"] != "" {
+	if service.MemLimit != 0 || service.CPULimit != 0 || service.DeployLabels["kompose.ephemeral-storage.limit"] != "" {
 		resourceLimit := api.ResourceList{}
 
 		if service.MemLimit != 0 {
@@ -823,7 +823,7 @@ func TranslatePodResource(service *kobject.ServiceConfig, template *api.PodTempl
 		}
 
 		// Check for ephemeral-storage in deploy labels
-		if val, ok := service.DeployLabels["limits.ephemeral-storage"]; ok {
+		if val, ok := service.DeployLabels["kompose.ephemeral-storage.limit"]; ok {
 			if quantity, err := resource.ParseQuantity(val); err == nil {
 				resourceLimit[api.ResourceEphemeralStorage] = quantity
 			}
@@ -833,7 +833,7 @@ func TranslatePodResource(service *kobject.ServiceConfig, template *api.PodTempl
 	}
 
 	// Configure the resource requests
-	if service.MemReservation != 0 || service.CPUReservation != 0 || service.DeployLabels["requests.ephemeral-storage"] != "" {
+	if service.MemReservation != 0 || service.CPUReservation != 0 || service.DeployLabels["kompose.ephemeral-storage.request"] != "" {
 		resourceRequests := api.ResourceList{}
 
 		if service.MemReservation != 0 {
@@ -845,7 +845,7 @@ func TranslatePodResource(service *kobject.ServiceConfig, template *api.PodTempl
 		}
 
 		// Check for ephemeral-storage in deploy labels
-		if val, ok := service.DeployLabels["requests.ephemeral-storage"]; ok {
+		if val, ok := service.DeployLabels["kompose.ephemeral-storage.request"]; ok {
 			if quantity, err := resource.ParseQuantity(val); err == nil {
 				resourceRequests[api.ResourceEphemeralStorage] = quantity
 			}

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -391,3 +391,8 @@ convert::expect_success "$os_cmd" "$os_output" || exit 1
 k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/label/compose.yaml convert --stdout --with-kompose-annotation=false"
 k8s_output="$KOMPOSE_ROOT/script/test/fixtures/label/output-k8s.yaml"
 convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1
+
+# Test deploy.labels in compose.yaml appears in the output
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/deploy/labels/compose.yaml convert --stdout --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/deploy/labels/output-k8s.yaml"
+convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1

--- a/script/test/fixtures/deploy/labels/compose.yaml
+++ b/script/test/fixtures/deploy/labels/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  app:
+    image: node:18-alpine
+    ports:
+      - 3000:3000
+    deploy:
+      labels:
+        requests.ephemeral-storage: 1Gi
+        limits.ephemeral-storage: 1Gi

--- a/script/test/fixtures/deploy/labels/compose.yaml
+++ b/script/test/fixtures/deploy/labels/compose.yaml
@@ -5,5 +5,5 @@ services:
       - 3000:3000
     deploy:
       labels:
-        requests.ephemeral-storage: 1Gi
-        limits.ephemeral-storage: 1Gi
+        kompose.ephemeral-storage.request: 1Gi
+        kompose.ephemeral-storage.limit: 1Gi

--- a/script/test/fixtures/deploy/labels/output-k8s.yaml
+++ b/script/test/fixtures/deploy/labels/output-k8s.yaml
@@ -19,8 +19,8 @@ kind: Deployment
 metadata:
   labels:
     io.kompose.service: app
-    limits.ephemeral-storage: 1Gi
-    requests.ephemeral-storage: 1Gi
+    kompose.ephemeral-storage.limit: 1Gi
+    kompose.ephemeral-storage.request: 1Gi
   name: app
 spec:
   replicas: 1

--- a/script/test/fixtures/deploy/labels/output-k8s.yaml
+++ b/script/test/fixtures/deploy/labels/output-k8s.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: app
+  name: app
+spec:
+  ports:
+    - name: "3000"
+      port: 3000
+      targetPort: 3000
+  selector:
+    io.kompose.service: app
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: app
+    limits.ephemeral-storage: 1Gi
+    requests.ephemeral-storage: 1Gi
+  name: app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: app
+  template:
+    metadata:
+      labels:
+        io.kompose.service: app
+    spec:
+      containers:
+        - image: node:18-alpine
+          name: app
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          resources:
+            limits:
+              ephemeral-storage: 1Gi
+            requests:
+              ephemeral-storage: 1Gi
+      restartPolicy: Always
+


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allow to use labels in the deploy section to convert to kubernetes resources requests and limits for ephemeral-storage

#### Which issue(s) this PR fixes:
Fixes #1935

#### Special notes for your reviewer:
❤️ 