### PR TITLE
bug: fix named volume detection logic

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -960,7 +960,7 @@ func (k *Kubernetes) ConfigVolumes(name string, service kobject.ServiceConfig) (
 		// check if ro/rw mode is defined, default rw
 		readonly := len(volume.Mode) > 0 && (volume.Mode == "ro" || volume.Mode == "rox")
 		mountHost := volume.Host
-		if mountHost == "" {
+		if volume.VolumeName == "" && mountHost == "" {
 			mountHost = volume.MountPath
 		}
 		// return useconfigmap and readonly,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently an input with a named volume defined in the same `docker-compose.yml` would produce an error like so:

> WARN File don't exist or failed to check if the directory is empty: stat :/app/data: no such file or directory

minimal example:

```yaml
---
services:
  example:
    image: bash
    volumes:
      - data:/app/data

volumes:
  data:
```

This bug was [introduced here](https://github.com/kubernetes/kompose/pull/1852/files#diff-1ff9d325f365a9e62567ac976258ba7a180503c6b53820c8f04b174d69b5e23fR960), the code for checking say `/app/data` in the example below, neglected to account for volumes like the one shown above.

```yaml
volumes:
  - /app/data
```

This PR simply adds a check to `data:`, as in `data:/app/data`, where as currently this is treated identically to just `/app/data`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
