### PR TITLE
Add no-interpolate feature option to the CLI

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -62,6 +62,9 @@ var (
 	// default is true.
 	WithKomposeAnnotation bool
 
+	// NoInterpolation decides if we will interpolate environment variables in the compose file.
+	NoInterpolate bool
+
 	// MultipleContainerMode which enables creating multi containers in a single pod is a developing function.
 	// default is false
 	MultipleContainerMode bool
@@ -121,6 +124,7 @@ var convertCmd = &cobra.Command{
 			YAMLIndent:                  ConvertYAMLIndent,
 			Profiles:                    ConvertProfiles,
 			WithKomposeAnnotation:       WithKomposeAnnotation,
+			NoInterpolate:               NoInterpolate,
 			MultipleContainerMode:       MultipleContainerMode,
 			ServiceGroupMode:            ServiceGroupMode,
 			ServiceGroupName:            ServiceGroupName,
@@ -202,6 +206,7 @@ func init() {
 	convertCmd.Flags().BoolVar(&GenerateNetworkPolicies, "generate-network-policies", false, "Specify whether to generate network policies or not")
 
 	convertCmd.Flags().BoolVar(&WithKomposeAnnotation, "with-kompose-annotation", true, "Add kompose annotations to generated resource")
+	convertCmd.Flags().BoolVar(&NoInterpolate, "no-interpolate", false, "Disable environment variable interpolation in the compose file")
 
 	// Deprecated commands
 	convertCmd.Flags().BoolVar(&ConvertEmptyVols, "emptyvols", false, "Use Empty Volumes. Do not generate PVCs")

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -206,7 +206,7 @@ func init() {
 	convertCmd.Flags().BoolVar(&GenerateNetworkPolicies, "generate-network-policies", false, "Specify whether to generate network policies or not")
 
 	convertCmd.Flags().BoolVar(&WithKomposeAnnotation, "with-kompose-annotation", true, "Add kompose annotations to generated resource")
-	convertCmd.Flags().BoolVar(&NoInterpolate, "no-interpolate", false, "Disable environment variable interpolation in the compose file")
+	convertCmd.Flags().BoolVar(&NoInterpolate, "no-interpolate", false, "Keep environment variable names in the Compose file")
 
 	// Deprecated commands
 	convertCmd.Flags().BoolVar(&ConvertEmptyVols, "emptyvols", false, "Use Empty Volumes. Do not generate PVCs")

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -218,7 +218,7 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 	komposeObject := kobject.KomposeObject{
 		ServiceConfigs: make(map[string]kobject.ServiceConfig),
 	}
-	komposeObject, err = l.LoadFile(opt.InputFiles, opt.Profiles)
+	komposeObject, err = l.LoadFile(opt.InputFiles, opt.Profiles, opt.NoInterpolate)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -92,6 +92,7 @@ type ConvertOptions struct {
 	ServiceGroupName        string
 	SecretsAsFiles          bool
 	GenerateNetworkPolicies bool
+	NoInterpolate           bool
 }
 
 // IsPodController indicate if the user want to use a controller

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -151,7 +151,7 @@ func checkUnsupportedKey(composeProject *types.Project) []string {
 }
 
 // LoadFile loads a compose file into KomposeObject
-func (c *Compose) LoadFile(files []string, profiles []string) (kobject.KomposeObject, error) {
+func (c *Compose) LoadFile(files []string, profiles []string, noInterpolate bool) (kobject.KomposeObject, error) {
 	// Gather the working directory
 	workingDir, err := transformer.GetComposeFileDir(files)
 	if err != nil {
@@ -161,7 +161,7 @@ func (c *Compose) LoadFile(files []string, profiles []string) (kobject.KomposeOb
 	projectOptions, err := cli.NewProjectOptions(
 		files, cli.WithOsEnv,
 		cli.WithWorkingDirectory(workingDir),
-		cli.WithInterpolation(true),
+		cli.WithInterpolation(!noInterpolate),
 		cli.WithProfiles(profiles),
 	)
 	if err != nil {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -25,7 +25,7 @@ import (
 
 // Loader interface defines loader that loads files and converts it to kobject representation
 type Loader interface {
-	LoadFile(files []string, profiles []string) (kobject.KomposeObject, error)
+	LoadFile(files []string, profiles []string, noInterpolate bool) (kobject.KomposeObject, error)
 	///Name() string
 }
 

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -276,6 +276,12 @@ k8s_output="$KOMPOSE_ROOT/script/test/fixtures/compose-env-interpolation/output-
 convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1
 convert::expect_success "$os_cmd" "$os_output" || exit 1
 
+# Test support for compose env without interpolation
+k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/compose-env-no-interpolation/compose.yaml convert --stdout --no-interpolate --with-kompose-annotation=false"
+k8s_output="$KOMPOSE_ROOT/script/test/fixtures/compose-env-no-interpolation/output-k8s.yaml"
+convert::expect_success "$k8s_cmd" "$k8s_output" || exit 1
+convert::expect_success "$os_cmd" "$os_output" || exit 1
+
 # Test support for subpath volume
 k8s_cmd="kompose -f $KOMPOSE_ROOT/script/test/fixtures/vols-subpath/compose.yaml convert --stdout --with-kompose-annotation=false"
 k8s_output="$KOMPOSE_ROOT/script/test/fixtures/vols-subpath/output-k8s.yaml"

--- a/script/test/fixtures/compose-env-no-interpolation/compose.yaml
+++ b/script/test/fixtures/compose-env-no-interpolation/compose.yaml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  foo:
+    image: ${DOCKER_REGISTRY-}foo:${IMAGE_TAG:-latest}
+    build: .
+    environment:
+      - VERSION=${IMAGE_TAG:-latest}
+    ports:
+      - 80:80

--- a/script/test/fixtures/compose-env-no-interpolation/output-k8s.yaml
+++ b/script/test/fixtures/compose-env-no-interpolation/output-k8s.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: foo
+  name: foo
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: foo
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: foo
+  name: foo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: foo
+  template:
+    metadata:
+      labels:
+        io.kompose.service: foo
+    spec:
+      containers:
+        - env:
+            - name: VERSION
+              value: ${IMAGE_TAG:-latest}
+          image: ${DOCKER_REGISTRY-}foo:${IMAGE_TAG:-latest}
+          name: foo
+          ports:
+            - containerPort: 80
+              protocol: TCP
+      restartPolicy: Always
+


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Allow the generated files to keep the environment variable placeholders in order to be interpolated in a later moment.

#### Which issue(s) this PR fixes:
Fixes #1953

#### Special notes for your reviewer:
This didn't pretend to put all compose keys to support the "env var placeholder" to not be interpolated, but the basic (most used ones) like "image" and "environments". Otherwise, it will be a huge effort to support this kind of feature. I guess each "non-supported" attribute can have it own issue and addressed as needed (as said in the #1953).