### PR TITLE
Add new instruction to permanently enable completion in the [bash|zsh|fish] shell

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -18,13 +18,13 @@ var completion = &cobra.Command{
 Auto completion supports bash, zsh and fish. Output is to STDOUT.
 
 # Enable auto-completion in bash  
-source <(kompose completion bash)
+echo "source <(kompose completion bash)" >> $HOME/.bashrc
 
 # Enable auto-completion in zsh  
-source <(kompose completion zsh)
+echo "source <(kompose completion zsh)" >> $HOME/.zshrc 
 
 # Enable auto-completion in fish 
-kompose completion fish | source
+echo "kompose completion fish | source" >> $HOME/fish/config.fish
 
 Will load the shell completion code.
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -17,11 +17,18 @@ var completion = &cobra.Command{
 
 Auto completion supports bash, zsh and fish. Output is to STDOUT.
 
+# Enable auto-completion in bash  
 source <(kompose completion bash)
+
+# Enable auto-completion in zsh  
 source <(kompose completion zsh)
+
+# Enable auto-completion in fish 
 kompose completion fish | source
 
 Will load the shell completion code.
+
+Note: To enable completion permanently in your shell place these shell commands in their respective shell configuration file.
 	`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
kompose completion generate a script that introduces a completion for the shell but this feature does not work for new instance of shell.

Fixes #1966 

#### Special notes for your reviewer:
