### PR TITLE
Align kompose env interpolation with k8s

### DIFF
--- a/client/convert_test.go
+++ b/client/convert_test.go
@@ -97,8 +97,8 @@ func TestConvertWithEnv(t *testing.T) {
 	assert.Check(t, is.Equal(err, nil))
 	for _, object := range objects {
 		if deployment, ok := object.(*appsv1.Deployment); ok {
-			assert.Check(t, is.Equal(deployment.Spec.Template.Spec.Containers[0].Args[2], "$REDIS_PASSWORD"))
-			assert.Check(t, is.Equal(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command, "redis-cli -a $REDIS_PASSWORD --raw incr ping"))
+			assert.Check(t, is.Equal(deployment.Spec.Template.Spec.Containers[0].Args[2], "$(REDIS_PASSWORD)"))
+			assert.Check(t, is.Equal(deployment.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command[0], "redis-cli -a $REDIS_PASSWORD --raw incr ping"))
 		}
 	}
 }

--- a/client/testdata/docker-compose-env.yaml
+++ b/client/testdata/docker-compose-env.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  redis:
+    image: redis
+    command: redis-server --requirepass $$REDIS_PASSWORD
+    healthcheck:
+      test: redis-cli -a $$REDIS_PASSWORD --raw incr ping
+    ports:
+      - 6379

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -1030,9 +1030,12 @@ func FormatResourceName(name string) string {
 
 // GetContainerArgs update the interpolation of env variables if exists.
 // example: [curl, $PROTOCOL://$DOMAIN] => [curl, $(PROTOCOL)://$(DOMAIN)]
+//
+// > Environment variable names consist of letters, numbers, underscores, dots, or hyphens, but the first character cannot be a digit
+// https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config
 func GetContainerArgs(service kobject.ServiceConfig) []string {
 	var args []string
-	re := regexp.MustCompile(`\$([a-zA-Z0-9]*)`)
+	re := regexp.MustCompile(`\$([a-zA-Z0-9.-_]+)`)
 	for _, arg := range service.Args {
 		arg = re.ReplaceAllString(arg, `$($1)`)
 		args = append(args, arg)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

It aligns the kompose env interpolation with the k8s according to [the docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#using-environment-variables-inside-of-your-config). 

#### Which issue(s) this PR fixes:

Fixes #1906

#### Special notes for your reviewer:
