### PR TITLE
Use format string in log.Fatalf for error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 toolchain go1.22.1
 
-replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20230704153349-abb98ff04d03
+require github.com/openshift/api v3.9.0+incompatible
 
 require (
 	github.com/compose-spec/compose-go/v2 v2.4.4
@@ -16,7 +16,6 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/novln/docker-parser v1.0.0
-	github.com/openshift/api v3.9.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cast v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openshift/api v0.0.0-20230704153349-abb98ff04d03 h1:qMeI0T0VAk3ydumBleYCbR7P2clyyEophp+dBCtCrJA=
-github.com/openshift/api v0.0.0-20230704153349-abb98ff04d03/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
+github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
+github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/pelletier/go-toml/v2 v2.2.1 h1:9TA9+T8+8CUCO2+WYnDLCgrYi9+omqKXyjDtosvtEhg=
 github.com/pelletier/go-toml/v2 v2.2.1/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -220,7 +220,7 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 	}
 	komposeObject, err = l.LoadFile(opt.InputFiles, opt.Profiles, opt.NoInterpolate)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%s", err.Error())
 	}
 
 	komposeObject.Namespace = opt.Namespace
@@ -243,7 +243,7 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 
 			relPath, err := filepath.Rel(workDir, envFile)
 			if err != nil {
-				log.Fatalf(err.Error())
+				log.Fatalf("%s", err.Error())
 			}
 
 			service.EnvFile[i] = filepath.ToSlash(relPath)
@@ -257,13 +257,13 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 	objects, err := t.Transform(komposeObject, opt)
 
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%s", err.Error())
 	}
 
 	// Print output
 	err = kubernetes.PrintList(objects, opt)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%s", err.Error())
 	}
 	return objects, err
 }


### PR DESCRIPTION
- Changed `log.Fatalf(err.Error())` to `log.Fatalf("%s", err.Error())`

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
