### PR TITLE
Use format string in log.Fatalf for error messages

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -220,7 +220,7 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 	}
 	komposeObject, err = l.LoadFile(opt.InputFiles, opt.Profiles, opt.NoInterpolate)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%s", err.Error())
 	}
 
 	komposeObject.Namespace = opt.Namespace
@@ -243,7 +243,7 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 
 			relPath, err := filepath.Rel(workDir, envFile)
 			if err != nil {
-				log.Fatalf(err.Error())
+				log.Fatalf("%s", err.Error())
 			}
 
 			service.EnvFile[i] = filepath.ToSlash(relPath)
@@ -257,13 +257,13 @@ func Convert(opt kobject.ConvertOptions) ([]runtime.Object, error) {
 	objects, err := t.Transform(komposeObject, opt)
 
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%s", err.Error())
 	}
 
 	// Print output
 	err = kubernetes.PrintList(objects, opt)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%s", err.Error())
 	}
 	return objects, err
 }


### PR DESCRIPTION
- Changed `log.Fatalf(err.Error())` to `log.Fatalf("%s", err.Error())`

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
