### PR TITLE
Fix ConfigMap name clash if env_file name is equal

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -973,12 +973,9 @@ func GetContentFromFile(file string) (string, error) {
 // FormatEnvName format env name
 func FormatEnvName(name string, serviceName string) string {
 	envName := strings.Trim(name, "./")
-	// only take string after the last slash only if the string contains a slash
-	if strings.Contains(envName, "/") {
-		envName = envName[strings.LastIndex(envName, "/")+1:]
-	}
 
-	envName = strings.Replace(envName, ".", "-", -1)
+	// replace all non-alphanumerical characters with dashes to have a unique envName (env filename could be used multiple times)
+	envName = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(envName, "-")
 	envName = getUsableNameEnvFile(envName, serviceName)
 	return envName
 }

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -547,7 +547,7 @@ func (k *Kubernetes) UpdateKubernetesObjectsMultipleContainers(name string, serv
 // UpdateKubernetesObjects loads configurations to k8s objects
 func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.ServiceConfig, opt kobject.ConvertOptions, objects *[]runtime.Object) error {
 	// Configure the environment variables.
-	envs, err := ConfigEnvs(service, opt)
+	envs, envsFrom, err := ConfigEnvs(service, opt)
 	if err != nil {
 		return errors.Wrap(err, "Unable to load env variables")
 	}
@@ -589,6 +589,7 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 	fillTemplate := func(template *api.PodTemplateSpec) error {
 		template.Spec.Containers[0].Name = GetContainerName(service)
 		template.Spec.Containers[0].Env = envs
+		template.Spec.Containers[0].EnvFrom = envsFrom
 		template.Spec.Containers[0].Command = service.Command
 		template.Spec.Containers[0].Args = GetContainerArgs(service)
 		template.Spec.Containers[0].WorkingDir = service.WorkingDir

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -875,7 +875,7 @@ func TestFormatEnvName(t *testing.T) {
 			args: args{
 				name: "random/test/v1",
 			},
-			want: "v1",
+			want: "random-test-v1",
 		},
 		{
 			name: "check that ./ is removed",
@@ -885,7 +885,7 @@ func TestFormatEnvName(t *testing.T) {
 			want: "random",
 		},
 		{
-			name: "check that ./ is removed",
+			name: "check that everything after $ is removed",
 			args: args{
 				name: "abcdefghijklnmopqrstuvxyzabcdefghijklmnopqrstuvwxyzabcdejghijkl$Hereisadditional",
 			},
@@ -897,7 +897,7 @@ func TestFormatEnvName(t *testing.T) {
 				name:        "src/app/.env",
 				serviceName: "app",
 			},
-			want: "app-env",
+			want: "src-app--env",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/transformer/kubernetes/podspec.go
+++ b/pkg/transformer/kubernetes/podspec.go
@@ -32,7 +32,7 @@ func AddContainer(service kobject.ServiceConfig, opt kobject.ConvertOptions) Pod
 			image = name
 		}
 
-		envs, err := ConfigEnvs(service, opt)
+		envs, envsFrom, err := ConfigEnvs(service, opt)
 		if err != nil {
 			panic("Unable to load env variables")
 		}
@@ -41,6 +41,7 @@ func AddContainer(service kobject.ServiceConfig, opt kobject.ConvertOptions) Pod
 			Name:           name,
 			Image:          image,
 			Env:            envs,
+			EnvFrom:        envsFrom,
 			Command:        service.Command,
 			Args:           service.Args,
 			WorkingDir:     service.WorkingDir,

--- a/script/test/fixtures/configmap-pod/output-k8s.yaml
+++ b/script/test/fixtures/configmap-pod/output-k8s.yaml
@@ -23,22 +23,11 @@ metadata:
   name: redis
 spec:
   containers:
-    - env:
-        - name: ALLOW_EMPTY_PASSWORD
-          valueFrom:
-            configMapKeyRef:
-              key: ALLOW_EMPTY_PASSWORD
-              name: foo-env
-        - name: BAR
-          valueFrom:
-            configMapKeyRef:
-              key: BAR
-              name: bar-env
-        - name: FOO
-          valueFrom:
-            configMapKeyRef:
-              key: FOO
-              name: bar-env
+    - envFrom:
+        - configMapRef:
+            name: foo-env
+        - configMapRef:
+            name: bar-env
       image: bitnami/redis:latest
       name: redis
       ports:

--- a/script/test/fixtures/configmap-pod/output-os.yaml
+++ b/script/test/fixtures/configmap-pod/output-os.yaml
@@ -23,22 +23,11 @@ metadata:
   name: redis
 spec:
   containers:
-    - env:
-        - name: ALLOW_EMPTY_PASSWORD
-          valueFrom:
-            configMapKeyRef:
-              key: ALLOW_EMPTY_PASSWORD
-              name: foo-env
-        - name: BAR
-          valueFrom:
-            configMapKeyRef:
-              key: BAR
-              name: bar-env
-        - name: FOO
-          valueFrom:
-            configMapKeyRef:
-              key: FOO
-              name: bar-env
+    - envFrom:
+        - configMapRef:
+            name: foo-env
+        - configMapRef:
+            name: bar-env
       image: bitnami/redis:latest
       name: redis
       ports:

--- a/script/test/fixtures/env/output-k8s.yaml
+++ b/script/test/fixtures/env/output-k8s.yaml
@@ -52,17 +52,9 @@ spec:
         io.kompose.service: another-namenode
     spec:
       containers:
-        - env:
-            - name: BAR
-              valueFrom:
-                configMapKeyRef:
-                  key: BAR
-                  name: hadoop-hive-namenode-env
-            - name: FOO
-              valueFrom:
-                configMapKeyRef:
-                  key: FOO
-                  name: hadoop-hive-namenode-env
+        - envFrom:
+            - configMapRef:
+                name: hadoop-hive-namenode-env
           image: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8
           name: another-namenode
           ports:
@@ -71,7 +63,6 @@ spec:
             - containerPort: 8020
               protocol: TCP
       restartPolicy: Always
-
 
 ---
 apiVersion: v1
@@ -103,18 +94,11 @@ spec:
     spec:
       containers:
         - env:
-            - name: BAR
-              valueFrom:
-                configMapKeyRef:
-                  key: BAR
-                  name: hadoop-hive-namenode-env
             - name: CLUSTER_NAME
               value: test
-            - name: FOO
-              valueFrom:
-                configMapKeyRef:
-                  key: FOO
-                  name: hadoop-hive-namenode-env
+          envFrom:
+            - configMapRef:
+                name: hadoop-hive-namenode-env
           image: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8
           name: namenode
           ports:
@@ -123,5 +107,4 @@ spec:
             - containerPort: 8020
               protocol: TCP
       restartPolicy: Always
-
 

--- a/script/test/fixtures/env/output-os.yaml
+++ b/script/test/fixtures/env/output-os.yaml
@@ -62,17 +62,9 @@ spec:
         io.kompose.service: another-namenode
     spec:
       containers:
-        - env:
-            - name: BAR
-              valueFrom:
-                configMapKeyRef:
-                  key: BAR
-                  name: hadoop-hive-namenode-env
-            - name: FOO
-              valueFrom:
-                configMapKeyRef:
-                  key: FOO
-                  name: hadoop-hive-namenode-env
+        - envFrom:
+            - configMapRef:
+                name: hadoop-hive-namenode-env
           image: ' '
           name: another-namenode
           ports:
@@ -129,18 +121,11 @@ spec:
     spec:
       containers:
         - env:
-            - name: BAR
-              valueFrom:
-                configMapKeyRef:
-                  key: BAR
-                  name: hadoop-hive-namenode-env
             - name: CLUSTER_NAME
               value: test
-            - name: FOO
-              valueFrom:
-                configMapKeyRef:
-                  key: FOO
-                  name: hadoop-hive-namenode-env
+          envFrom:
+            - configMapRef:
+                name: hadoop-hive-namenode-env
           image: ' '
           name: namenode
           ports:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind bug

#### What this PR does / why we need it:

Fixes naming collisions if env files have same filename in different folders.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #2000

#### Special notes for your reviewer:
