### PR TITLE
fix: fix set service type to nodeport or loadbalancer, but get defaul…

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -432,7 +432,7 @@ func (k *Kubernetes) initSvcObject(name string, service kobject.ServiceConfig, p
 	svc.Spec.Selector = transformer.ConfigLabels(service.Name)
 
 	svc.Spec.Ports = ports
-	svc.Spec.Type = api.ServiceType(service.ServiceType)
+	svc.Spec.Type = api.ServiceType(service.GetServiceType())
 
 	// Configure annotations
 	annotations := transformer.ConfigAnnotations(service)
@@ -458,17 +458,18 @@ func (k *Kubernetes) CreateLBService(name string, service kobject.ServiceConfig)
 
 // CreateService creates a k8s service
 func (k *Kubernetes) CreateService(name string, service kobject.ServiceConfig) *api.Service {
+	serviceType := service.GetServiceType()
 	svc := k.InitSvc(name, service)
 
 	// Configure the service ports.
 	servicePorts := k.ConfigServicePorts(service)
 	svc.Spec.Ports = servicePorts
 
-	if service.ServiceType == "Headless" {
+	if serviceType == "Headless" {
 		svc.Spec.Type = api.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "None"
 	} else {
-		svc.Spec.Type = api.ServiceType(service.ServiceType)
+		svc.Spec.Type = api.ServiceType(serviceType)
 	}
 
 	// Configure annotations

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -329,6 +329,98 @@ func TestCreateServiceWithServiceUser(t *testing.T) {
 	}
 }
 
+/*
+Test the creation of a service with service type NodePort.
+The expected result is that Kompose will set user in PodSpec
+*/
+func TestCreateServiceWithServiceTypeNodePort(t *testing.T) {
+	// An example service
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		Environment:   []kobject.EnvVar{{Name: "env", Value: "value"}},
+		Port:          []kobject.Ports{{HostPort: 123, ContainerPort: 456, Protocol: string(corev1.ProtocolTCP)}},
+		Command:       []string{"cmd"},
+		WorkingDir:    "dir",
+		Args:          []string{"arg1", "arg2"},
+		VolList:       []string{"/tmp/volume"},
+		Network:       []string{"network1", "network2"}, // not supported
+		DeployLabels:  map[string]string{"kompose.service.type": "nodeport", "kompose.service": "my-service"},
+		Annotations:   map[string]string{"kompose.service.type": "nodeport"},
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
+		Privileged:    true,
+		Restart:       "always",
+		User:          "1234:5678",
+	}
+
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+
+	objects, err := k.Transform(komposeObject, kobject.ConvertOptions{CreateD: true, Replicas: 1})
+	if err != nil {
+		t.Error(errors.Wrap(err, "k.Transform failed"))
+	}
+
+	for _, obj := range objects {
+		if svc, ok := obj.(*corev1.Service); ok {
+			if svc.Spec.Type != corev1.ServiceTypeNodePort {
+				t.Errorf("Service type is not NodePort")
+			}
+		}
+	}
+}
+
+/*
+Test the creation of a service with service type LoadBalancer.
+The expected result is that Kompose will set user in PodSpec
+*/
+func TestCreateServiceWithServiceTypeLoadBalancer(t *testing.T) {
+	// An example service
+	service := kobject.ServiceConfig{
+		ContainerName: "name",
+		Image:         "image",
+		Environment:   []kobject.EnvVar{{Name: "env", Value: "value"}},
+		Port:          []kobject.Ports{{HostPort: 123, ContainerPort: 456, Protocol: string(corev1.ProtocolTCP)}},
+		Command:       []string{"cmd"},
+		WorkingDir:    "dir",
+		Args:          []string{"arg1", "arg2"},
+		VolList:       []string{"/tmp/volume"},
+		Network:       []string{"network1", "network2"}, // not supported
+		DeployLabels:  map[string]string{"kompose.service.type": "loadbalancer", "kompose.service": "my-service"},
+		Annotations:   map[string]string{"kompose.service.type": "loadbalancer"},
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
+		Privileged:    true,
+		Restart:       "always",
+		User:          "1234:5678",
+	}
+
+	komposeObject := kobject.KomposeObject{
+		ServiceConfigs: map[string]kobject.ServiceConfig{"app": service},
+	}
+	k := Kubernetes{}
+
+	objects, err := k.Transform(komposeObject, kobject.ConvertOptions{CreateD: true, Replicas: 1})
+	if err != nil {
+		t.Error(errors.Wrap(err, "k.Transform failed"))
+	}
+
+	for _, obj := range objects {
+		if svc, ok := obj.(*corev1.Service); ok {
+			if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+				t.Errorf("Service type is not NodePort")
+			}
+		}
+	}
+}
+
 func TestCreateServiceWithConfigLongSyntax(t *testing.T) {
 	content := "setting: true"
 	target := "/etc/config.yaml"

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -408,6 +408,9 @@ func (o *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 					log.Warningf("Create multiple service to avoid using mixed protocol in the same service when it's loadbalancer type")
 				}
 			} else {
+				if err = service.CheckServiceType(); err != nil {
+					return nil, errors.Wrap(err, "CheckServiceType failed")
+				}
 				svc := o.CreateService(name, service)
 				objects = append(objects, svc)
 


### PR DESCRIPTION
#### What type of PR is this?

- fix set service type to nodeport or loadbalancer, but get default type
- add some test for different type of service

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
resolve https://github.com/kubernetes/kompose/issues/2043

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/kubernetes/kompose/issues/2043
