### PR TITLE
feature: add support for hostAliases

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -170,8 +170,9 @@ type ServiceConfig struct {
 	CronJobBackoffLimit      *int32                    `compose:"kompose.cronjob.backoff_limit"`
 	Volumes                  []Volumes                 `compose:""`
 	Secrets                  []types.ServiceSecretConfig
-	HealthChecks             HealthChecks `compose:""`
-	Placement                Placement    `compose:""`
+	HealthChecks             HealthChecks  `compose:""`
+	Placement                Placement     `compose:""`
+	HostAliases              []HostAliases `compose:""`
 	//This is for long LONG SYNTAX link(https://docs.docker.com/compose/compose-file/#long-syntax)
 	Configs []types.ServiceConfigObjConfig `compose:""`
 	//This is for SHORT SYNTAX link(https://docs.docker.com/compose/compose-file/#configs)
@@ -214,6 +215,11 @@ type Ports struct {
 	ContainerPort int32
 	HostIP        string
 	Protocol      string // Upper string
+}
+
+type HostAliases struct {
+	IP        string
+	Hostnames []string
 }
 
 // ID returns an unique id for this port settings, to avoid conflict

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -718,6 +718,18 @@ func (k *Kubernetes) UpdateKubernetesObjects(name string, service kobject.Servic
 			template.Spec.Subdomain = service.DomainName
 		}
 
+		// Configure hostAliases
+		if len(service.HostAliases) > 0 {
+			var hostAliases []api.HostAlias
+			for _, ha := range service.HostAliases {
+				hostAliases = append(hostAliases, api.HostAlias{
+					IP:        ha.IP,
+					Hostnames: ha.Hostnames,
+				})
+			}
+			template.Spec.HostAliases = hostAliases
+		}
+
 		if serviceAccountName, ok := service.Labels[compose.LabelServiceAccountName]; ok {
 			template.Spec.ServiceAccountName = serviceAccountName
 		}

--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -1646,6 +1646,7 @@ func (k *Kubernetes) Transform(komposeObject kobject.KomposeObject, opt kobject.
 					SecurityContext(groupName, service),
 					HostName(service),
 					DomainName(service),
+					HostAliases(service),
 					ResourcesLimits(service),
 					ResourcesRequests(service),
 					TerminationGracePeriodSeconds(groupName, service),

--- a/pkg/transformer/kubernetes/podspec.go
+++ b/pkg/transformer/kubernetes/podspec.go
@@ -299,6 +299,20 @@ func DomainName(service kobject.ServiceConfig) PodSpecOption {
 	}
 }
 
+// HostAliases configure the host aliases of a pod
+func HostAliases(service kobject.ServiceConfig) PodSpecOption {
+	return func(podSpec *PodSpec) {
+		if len(service.HostAliases) > 0 {
+			for _, ha := range service.HostAliases {
+				podSpec.HostAliases = append(podSpec.HostAliases, api.HostAlias{
+					IP:        ha.IP,
+					Hostnames: ha.Hostnames,
+				})
+			}
+		}
+	}
+}
+
 func configProbe(healthCheck kobject.HealthCheck) *api.Probe {
 	probe := api.Probe{}
 	// We check to see if it's blank or disable


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds support for converting Docker Compose's `extra_hosts` field to Kubernetes' `hostAliases` field in Pod specifications.

When a `docker-compose.yaml` file contains `extra_hosts` entries, Kompose will now automatically convert them to the equivalent Kubernetes `hostAliases` configuration. This allows users to maintain custom host-to-IP mappings when migrating from Docker Compose to Kubernetes.

#### Which issue(s) this PR fixes:
Fixes #2066 

#### Special notes for your reviewer:

- The conversion logic maps each `extra_hosts` entry (format: "hostname:ip") to a corresponding `hostAliases` entry with the IP and hostname
- Added unit tests to verify the conversion behavior