### PR TITLE
fix(tests): improve test compatibility for macOS and podman

### DIFF
--- a/script/test/fixtures/buildargs/compose.yaml
+++ b/script/test/fixtures/buildargs/compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
     foo:

--- a/script/test/fixtures/buildconfig/compose-build-no-image.yaml
+++ b/script/test/fixtures/buildconfig/compose-build-no-image.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
     foo:

--- a/script/test/fixtures/buildconfig/compose-dockerfile.yaml
+++ b/script/test/fixtures/buildconfig/compose-dockerfile.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
     foo:

--- a/script/test/fixtures/buildconfig/compose-v3.yaml
+++ b/script/test/fixtures/buildconfig/compose-v3.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
     foo:

--- a/script/test/fixtures/buildconfig/compose.yaml
+++ b/script/test/fixtures/buildconfig/compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
     foo:

--- a/script/test/fixtures/change-in-volume/compose.yaml
+++ b/script/test/fixtures/change-in-volume/compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   web:
     image: flask_web      

--- a/script/test/fixtures/compose-env-interpolation/compose.yaml
+++ b/script/test/fixtures/compose-env-interpolation/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   foo:

--- a/script/test/fixtures/compose-env-no-interpolation/compose.yaml
+++ b/script/test/fixtures/compose-env-no-interpolation/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   foo:

--- a/script/test/fixtures/compose-file-env-variable/alternative-compose.yaml
+++ b/script/test/fixtures/compose-file-env-variable/alternative-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   alpine:
     image: alpine

--- a/script/test/fixtures/compose-file-env-variable/compose.yaml
+++ b/script/test/fixtures/compose-file-env-variable/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   debian:
     image: debian

--- a/script/test/fixtures/compose-file-support/compose.yaml
+++ b/script/test/fixtures/compose-file-support/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     image: nginx:latest

--- a/script/test/fixtures/compose-v3.3-test/compose-config-long-warning.yaml
+++ b/script/test/fixtures/compose-v3.3-test/compose-config-long-warning.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis:
     image: redis:latest

--- a/script/test/fixtures/compose-v3.3-test/compose-config-long.yaml
+++ b/script/test/fixtures/compose-v3.3-test/compose-config-long.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis:
     image: redis:latest

--- a/script/test/fixtures/compose-v3.3-test/compose-config-short-warning.yaml
+++ b/script/test/fixtures/compose-v3.3-test/compose-config-short-warning.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis:
     image: redis:latest

--- a/script/test/fixtures/compose-v3.3-test/compose-config-short.yaml
+++ b/script/test/fixtures/compose-v3.3-test/compose-config-short.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis:
     image: redis:latest

--- a/script/test/fixtures/compose-v3.3-test/compose-endpoint-mode-1.yaml
+++ b/script/test/fixtures/compose-v3.3-test/compose-endpoint-mode-1.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   wordpress:

--- a/script/test/fixtures/compose-v3.3-test/compose-endpoint-mode-2.yaml
+++ b/script/test/fixtures/compose-v3.3-test/compose-endpoint-mode-2.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   wordpress:

--- a/script/test/fixtures/configmap-pod/compose.yaml
+++ b/script/test/fixtures/configmap-pod/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   redis:

--- a/script/test/fixtures/configmap-volume/compose-withlabel.yaml
+++ b/script/test/fixtures/configmap-volume/compose-withlabel.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     image: nginx

--- a/script/test/fixtures/configmap-volume/compose.yaml
+++ b/script/test/fixtures/configmap-volume/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     image: nginx

--- a/script/test/fixtures/configmap/compose.yaml
+++ b/script/test/fixtures/configmap/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   redis:

--- a/script/test/fixtures/controller/compose-controller-label-v3.yaml
+++ b/script/test/fixtures/controller/compose-controller-label-v3.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     image: wordpress:4

--- a/script/test/fixtures/controller/compose-global.yaml
+++ b/script/test/fixtures/controller/compose-global.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   worker:
     image: dockersamples/examplevotingapp_worker

--- a/script/test/fixtures/controller/compose.yaml
+++ b/script/test/fixtures/controller/compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
 

--- a/script/test/fixtures/cronjob/compose.yaml
+++ b/script/test/fixtures/cronjob/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   challenge:

--- a/script/test/fixtures/deploy/placement/compose-placement.yaml
+++ b/script/test/fixtures/deploy/placement/compose-placement.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   redis:
     image: redis

--- a/script/test/fixtures/dockerfilepath/compose.yaml
+++ b/script/test/fixtures/dockerfilepath/compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
  foo:

--- a/script/test/fixtures/domain/compose-v3.yaml
+++ b/script/test/fixtures/domain/compose-v3.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   dns:
     image: phensley/docker-dns

--- a/script/test/fixtures/domain/compose.yaml
+++ b/script/test/fixtures/domain/compose.yaml
@@ -1,4 +1,3 @@
-version: 2
 services:
   dns:
     image: phensley/docker-dns

--- a/script/test/fixtures/entrypoint-command/compose.yaml
+++ b/script/test/fixtures/entrypoint-command/compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 
 services:
   base:

--- a/script/test/fixtures/env-dotenv/compose.yaml
+++ b/script/test/fixtures/env-dotenv/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   minio:
     image: quay.io/minio/minio:RELEASE.2023-12-20T01-00-02Z

--- a/script/test/fixtures/env-multiple/compose.yaml
+++ b/script/test/fixtures/env-multiple/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8

--- a/script/test/fixtures/env/compose.yaml
+++ b/script/test/fixtures/env/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop2.7.4-java8

--- a/script/test/fixtures/envfile-interpolation/compose.yaml
+++ b/script/test/fixtures/envfile-interpolation/compose.yaml
@@ -1,4 +1,3 @@
-version: '3' 
 
 services:
   minio:

--- a/script/test/fixtures/envvars-interpolation/compose.yaml
+++ b/script/test/fixtures/envvars-interpolation/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.5'
 
 services:
     myservice:

--- a/script/test/fixtures/etherpad/docker-compose-no-image.yml
+++ b/script/test/fixtures/etherpad/docker-compose-no-image.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   mariadb:

--- a/script/test/fixtures/etherpad/docker-compose-no-ports.yml
+++ b/script/test/fixtures/etherpad/docker-compose-no-ports.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   mariadb:

--- a/script/test/fixtures/etherpad/docker-compose.yml
+++ b/script/test/fixtures/etherpad/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   mariadb:

--- a/script/test/fixtures/expose/compose.yaml
+++ b/script/test/fixtures/expose/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.5'
 services:
   web:
     image: tuna/docker-counter23

--- a/script/test/fixtures/external-traffic-policy/compose-v1.yaml
+++ b/script/test/fixtures/external-traffic-policy/compose-v1.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   front-end:

--- a/script/test/fixtures/external-traffic-policy/compose-v2.yaml
+++ b/script/test/fixtures/external-traffic-policy/compose-v2.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   front-end:

--- a/script/test/fixtures/fsgroup/compose.yaml
+++ b/script/test/fixtures/fsgroup/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 volumes:
   pgadmin-data:
 

--- a/script/test/fixtures/gitlab/docker-compose.yml
+++ b/script/test/fixtures/gitlab/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   postgresql:

--- a/script/test/fixtures/healthcheck/compose-healthcheck.yaml
+++ b/script/test/fixtures/healthcheck/compose-healthcheck.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   # test exec
   redis:

--- a/script/test/fixtures/host-port-protocol/compose.yaml
+++ b/script/test/fixtures/host-port-protocol/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   nginx:

--- a/script/test/fixtures/hpa/compose.yaml
+++ b/script/test/fixtures/hpa/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   web:
     image: nginx

--- a/script/test/fixtures/image-pull-policy/compose-files/v12-fail-image-pull-policy.yml
+++ b/script/test/fixtures/image-pull-policy/compose-files/v12-fail-image-pull-policy.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   nginx0:
     image: nginx

--- a/script/test/fixtures/image-pull-policy/compose-files/v12-image-pull-policy.yml
+++ b/script/test/fixtures/image-pull-policy/compose-files/v12-image-pull-policy.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   nginx0:
     image: nginx

--- a/script/test/fixtures/image-pull-policy/compose-files/v3-image-pull-policy.yml
+++ b/script/test/fixtures/image-pull-policy/compose-files/v3-image-pull-policy.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   nginx0:
     image: nginx

--- a/script/test/fixtures/initcontainer/compose.yaml
+++ b/script/test/fixtures/initcontainer/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     image: nginx

--- a/script/test/fixtures/keyonly-envs/env.yml
+++ b/script/test/fixtures/keyonly-envs/env.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   redis-master:

--- a/script/test/fixtures/label-port/docker-compose.yml
+++ b/script/test/fixtures/label-port/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   webapiapplication:
     image: webapiapplication

--- a/script/test/fixtures/multiple-files/first.yaml
+++ b/script/test/fixtures/multiple-files/first.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   foo:
     image: foo

--- a/script/test/fixtures/multiple-files/second.yaml
+++ b/script/test/fixtures/multiple-files/second.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   bar:
     deploy:

--- a/script/test/fixtures/multiple-type-volumes/compose.yaml
+++ b/script/test/fixtures/multiple-type-volumes/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   web:
     image: nginx

--- a/script/test/fixtures/namespace/compose.yaml
+++ b/script/test/fixtures/namespace/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     image: nginx

--- a/script/test/fixtures/network-mode-service/compose.yaml
+++ b/script/test/fixtures/network-mode-service/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   client:

--- a/script/test/fixtures/network-policies/compose.yaml
+++ b/script/test/fixtures/network-policies/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 networks:
   web:

--- a/script/test/fixtures/network/compose-v3.yaml
+++ b/script/test/fixtures/network/compose-v3.yaml
@@ -1,4 +1,3 @@
-version: '3'
 networks:
   app:
     external:

--- a/script/test/fixtures/nginx-node-redis/compose-v3.yaml
+++ b/script/test/fixtures/nginx-node-redis/compose-v3.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   nginx:

--- a/script/test/fixtures/nginx-node-redis/compose.yaml
+++ b/script/test/fixtures/nginx-node-redis/compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   nginx:

--- a/script/test/fixtures/no-profile-warning/compose.yaml
+++ b/script/test/fixtures/no-profile-warning/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     image: nginx

--- a/script/test/fixtures/ports-with-ip/docker-compose.yml
+++ b/script/test/fixtures/ports-with-ip/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
     web:

--- a/script/test/fixtures/pvc-request-size/compose.yaml
+++ b/script/test/fixtures/pvc-request-size/compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 
 services:
   redis:

--- a/script/test/fixtures/resources-lowercase/compose.yaml
+++ b/script/test/fixtures/resources-lowercase/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   NGINX:
     image: nginx:latest

--- a/script/test/fixtures/secrets/docker-compose-secrets-long.yml
+++ b/script/test/fixtures/secrets/docker-compose-secrets-long.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   redis:
     image: redis:latest

--- a/script/test/fixtures/secrets/docker-compose-secrets-short.yml
+++ b/script/test/fixtures/secrets/docker-compose-secrets-short.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   redis:
     image: redis:latest

--- a/script/test/fixtures/service-group/compose.yaml
+++ b/script/test/fixtures/service-group/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 
 services:
   librenms:

--- a/script/test/fixtures/service-label/docker-compose.yaml
+++ b/script/test/fixtures/service-label/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   mariadb:
     ports:

--- a/script/test/fixtures/service-name-change/docker-compose.yml
+++ b/script/test/fixtures/service-name-change/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   mariadb:
     labels:

--- a/script/test/fixtures/single-file-output/compose.yaml
+++ b/script/test/fixtures/single-file-output/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 
 services:
   front_end:

--- a/script/test/fixtures/statefulset/compose.yaml
+++ b/script/test/fixtures/statefulset/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
     
 services:
   db:

--- a/script/test/fixtures/stdin-true/docker-compose.yml
+++ b/script/test/fixtures/stdin-true/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   client:
     image: registry.centos.org/centos/centos:7

--- a/script/test/fixtures/stdin/docker-compose.yaml
+++ b/script/test/fixtures/stdin/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   backend:
     image: helloworld

--- a/script/test/fixtures/storage-class-name/compose.yaml
+++ b/script/test/fixtures/storage-class-name/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   nginx:
     image: nginx

--- a/script/test/fixtures/tty-true/docker-compose.yml
+++ b/script/test/fixtures/tty-true/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   client:
     image: registry.centos.org/centos/centos:7

--- a/script/test/fixtures/unused/merge-multiple-compose/base.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/base.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   web:

--- a/script/test/fixtures/unused/merge-multiple-compose/compose-new-service-prob.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/compose-new-service-prob.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   server:

--- a/script/test/fixtures/unused/merge-multiple-compose/compose-port-base.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/compose-port-base.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   server:

--- a/script/test/fixtures/unused/merge-multiple-compose/compose-port-prod.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/compose-port-prod.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   server:

--- a/script/test/fixtures/unused/merge-multiple-compose/dev.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/dev.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   web:

--- a/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-base.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-base.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   other-toplevel-base:

--- a/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-dev.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-dev.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   other-toplevel-dev:

--- a/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-ext.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-ext.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 services:
   other-toplevel-second:

--- a/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-override.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/other-toplevel-override.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 
 volumes:
   firstvolume:

--- a/script/test/fixtures/unused/merge-multiple-compose/service-merge-concat-base.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/service-merge-concat-base.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   server:

--- a/script/test/fixtures/unused/merge-multiple-compose/service-merge-concat-override.yml
+++ b/script/test/fixtures/unused/merge-multiple-compose/service-merge-concat-override.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   server:

--- a/script/test/fixtures/unused/v3/docker-compose-3.5.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-3.5.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 
 services:
 

--- a/script/test/fixtures/unused/v3/docker-compose-deploy.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-deploy.yaml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   vote: # test placement and update_config
     image: dockersamples/examplevotingapp_vote:before

--- a/script/test/fixtures/unused/v3/docker-compose-env-subs.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-env-subs.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   foo:
     image: foo/bar:latest

--- a/script/test/fixtures/unused/v3/docker-compose-env.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-env.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   foo:
     labels:

--- a/script/test/fixtures/unused/v3/docker-compose-full-example.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-full-example.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   foo:

--- a/script/test/fixtures/unused/v3/docker-compose-memcpu-partial.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-memcpu-partial.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   foo:

--- a/script/test/fixtures/unused/v3/docker-compose-memcpu.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-memcpu.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   foo:

--- a/script/test/fixtures/unused/v3/docker-compose-unset-env.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-unset-env.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   foo:
     labels:

--- a/script/test/fixtures/unused/v3/docker-compose-volumes.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose-volumes.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
 

--- a/script/test/fixtures/unused/v3/docker-compose.yaml
+++ b/script/test/fixtures/unused/v3/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
 

--- a/script/test/fixtures/v2/compose.yaml
+++ b/script/test/fixtures/v2/compose.yaml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   foo:

--- a/script/test/fixtures/v3.0/compose.yaml
+++ b/script/test/fixtures/v3.0/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   redis:

--- a/script/test/fixtures/vols-subpath/compose.yaml
+++ b/script/test/fixtures/vols-subpath/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 volumes:
   postgres-data:
 

--- a/script/test/fixtures/volume-mounts/hostpath/docker-compose-v3.yml
+++ b/script/test/fixtures/volume-mounts/hostpath/docker-compose-v3.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres:10.1

--- a/script/test/fixtures/volume-mounts/hostpath/docker-compose.yml
+++ b/script/test/fixtures/volume-mounts/hostpath/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   db:
     image: postgres:10.1

--- a/script/test/fixtures/volume-mounts/named-volume/docker-compose-v3.yml
+++ b/script/test/fixtures/volume-mounts/named-volume/docker-compose-v3.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres:10.1

--- a/script/test/fixtures/volume-mounts/named-volume/docker-compose.yml
+++ b/script/test/fixtures/volume-mounts/named-volume/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   db:
     image: postgres:10.1

--- a/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml
+++ b/script/test/fixtures/volume-mounts/simple-vol-mounts/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   httpd:

--- a/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml
+++ b/script/test/fixtures/volume-mounts/tmpfs/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
 

--- a/script/test/fixtures/volume-mounts/volumes-from/docker-compose-case.yml
+++ b/script/test/fixtures/volume-mounts/volumes-from/docker-compose-case.yml
@@ -1,4 +1,3 @@
-version: '2'
 
 services:
 

--- a/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml
+++ b/script/test/fixtures/volume-mounts/volumes-from/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 
 services:
   web:

--- a/script/test/fixtures/volume-mounts/windows/compose.yaml
+++ b/script/test/fixtures/volume-mounts/windows/compose.yaml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   db:
     image: nginx:latest


### PR DESCRIPTION
fix(tests): improve test compatibility for macOS and podman

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
-->

/kind cleanup

#### What this PR does / why we need it:

- Remove deprecated 'version' attribute that we no longer use across all
  fixture files (confirmed they still convert 1-1)

- Added macOS compatibility, using grealpath instead since it's a bit
  different on macOS vs Linux

- Container connection on build for machines without podman or docker

- Fixed typos

- Fixes tests usually having warnings that no longer do

- Fix bug with state validation

TLDR; CI is finally passing again after some clean up

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

N/A, spring clean up fixing up Kompose testing again for any newcomers

#### Special notes for your reviewer:

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
