### PR TITLE
fix: remove double base64 encoding of ConfigMap binaryData

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -356,7 +355,7 @@ func initConfigMapData(configMap *api.ConfigMap, data map[string]string) {
 		if isText {
 			stringData[k] = lfText
 		} else {
-			binData[k] = []byte(base64.StdEncoding.EncodeToString([]byte(v)))
+			binData[k] = []byte(v)
 		}
 	}
 


### PR DESCRIPTION
Fixes #2082

## Problem

When converting Docker Compose configs to Kubernetes ConfigMaps, binary data is manually base64-encoded before being assigned to `ConfigMap.BinaryData`:

```go
binData[k] = []byte(base64.StdEncoding.EncodeToString([]byte(v)))
```

However, `ConfigMap.BinaryData` is of type `map[string][]byte` and Kubernetes automatically base64-encodes the raw bytes during YAML/JSON serialization. This results in **double base64 encoding** — decoding once yields another base64 string instead of the original binary data.

## Fix

Remove the manual `base64.StdEncoding.EncodeToString()` call and pass raw bytes directly:

```go
binData[k] = []byte(v)
```

This is a one-line fix (plus removing the unused `encoding/base64` import).