### PR TITLE
fix: normalize underscores to dashes in Service metadata.name

### DIFF
--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -587,10 +587,12 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 			return kobject.KomposeObject{}, err
 		}
 
-		// Log if the name will been changed
-		if normalizeServiceNames(name) != name {
-			log.Infof("Service name in docker-compose has been changed from %q to %q", name, normalizeServiceNames(name))
+		// Normalize the service name for Kubernetes (e.g. replace underscores with dashes)
+		normalizedName := normalizeServiceNames(name)
+		if normalizedName != name {
+			log.Infof("Service name in docker-compose has been changed from %q to %q", name, normalizedName)
 		}
+		serviceConfig.Name = normalizedName
 
 		serviceConfig.Configs = composeServiceConfig.Configs
 		serviceConfig.ConfigsMetaData = composeObject.Configs
@@ -603,7 +605,7 @@ func dockerComposeToKomposeMapping(composeObject *types.Project) (kobject.Kompos
 		serviceConfig.GroupAdd = groupAdd
 
 		// Final step, add to the array!
-		komposeObject.ServiceConfigs[normalizeServiceNames(name)] = serviceConfig
+		komposeObject.ServiceConfigs[normalizedName] = serviceConfig
 	}
 
 	handleVolume(&komposeObject, &composeObject.Volumes)

--- a/pkg/loader/compose/compose_test.go
+++ b/pkg/loader/compose/compose_test.go
@@ -574,6 +574,30 @@ func TestNormalizeServiceNames(t *testing.T) {
 	}
 }
 
+func TestServiceConfigNameNormalized(t *testing.T) {
+	project := &types.Project{
+		Services: types.Services{
+			"my_service": types.ServiceConfig{
+				Name:  "my_service",
+				Image: "nginx",
+			},
+		},
+	}
+
+	komposeObject, err := dockerComposeToKomposeMapping(project)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	sc, ok := komposeObject.ServiceConfigs["my-service"]
+	if !ok {
+		t.Fatal("Expected service config key 'my-service' but it was not found")
+	}
+	if sc.Name != "my-service" {
+		t.Errorf("Expected serviceConfig.Name to be %q, got %q", "my-service", sc.Name)
+	}
+}
+
 func TestNormalizeNetworkNames(t *testing.T) {
 	testCases := []struct {
 		composeNetworkName    string


### PR DESCRIPTION
## Summary

Fixes #1897

When a Docker Compose service name contains underscores (e.g., `my_web_app`), kompose correctly normalizes the map key and most resource names to use dashes (`my-web-app`), but the `serviceConfig.Name` field retains underscores because it's set via `parseResourceName()` which uses `normalizeContainerNames()` (lowercase only, no underscore replacement).

This causes the Kubernetes **Service** `metadata.name` to contain underscores (`my_web_app`) while other resources like **Deployments** correctly use dashes (`my-web-app`).

## Root Cause

In `dockerComposeToKomposeMapping()`, `serviceConfig.Name` is initially set from `parseResourceName()` which calls `normalizeContainerNames()`. The map key is set from `normalizeServiceNames()` (which replaces underscores with dashes), but `serviceConfig.Name` is never updated to match.

## Fix

Set `serviceConfig.Name` to the result of `normalizeServiceNames()` so all generated Kubernetes resources use consistent, DNS-valid names.

## Before (stock kompose)

```
$ kompose convert -f docker-compose.yaml --stdout
# Service gets: name: my_web_app    ← invalid, has underscores
# Deployment gets: name: my-web-app ← correct
```

## After (patched)

```
$ kompose convert -f docker-compose.yaml --stdout
# Service gets: name: my-web-app    ← correct
# Deployment gets: name: my-web-app ← correct
```

## Test Plan

- Added `TestServiceConfigNameNormalized` unit test that:
  - Creates a compose project with service name `my_service`
  - Verifies `serviceConfig.Name` is `my-service` after mapping
  - Confirmed test **fails** without the fix, **passes** with it
- All existing tests pass (`go test ./...`)
- End-to-end verification with `kompose convert --stdout`