### PR TITLE
fix: recurse checkIsEmptyDir with correct path and nested emptiness detection

### DIFF
--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -1278,9 +1278,12 @@ func checkIsEmptyDir(filePath string) (bool, error) {
 		if !file.IsDir() {
 			return false, nil
 		}
-		_, err := checkIsEmptyDir(file.Name())
+		isEmpty, err := checkIsEmptyDir(filepath.Join(filePath, file.Name()))
 		if err != nil {
 			return false, err
+		}
+		if !isEmpty {
+			return false, nil
 		}
 	}
 	return true, nil

--- a/pkg/transformer/kubernetes/k8sutils_test.go
+++ b/pkg/transformer/kubernetes/k8sutils_test.go
@@ -2503,6 +2503,15 @@ func Test_isConfigFile(t *testing.T) {
 			wantSkip:         false,
 		},
 		{
+			name: "nested dir not empty",
+			args: args{
+				filePath: "../../../script/test/fixtures/configmap-file-configs/certs-level1",
+			},
+			wantUseConfigMap: true,
+			wantReadonly:     true,
+			wantSkip:         false,
+		},
+		{
 			name: "sock",
 			args: args{
 				filePath: "./docker.sock",
@@ -2590,6 +2599,14 @@ func Test_checkIsEmptyDir(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		},
+		{
+			name: "nested dir not empty",
+			args: args{
+				filePath: "../../../script/test/fixtures/configmap-file-configs/certs-level1",
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2602,6 +2619,39 @@ func Test_checkIsEmptyDir(t *testing.T) {
 				t.Errorf("checkIsEmptyDir() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_checkIsEmptyDir_nestedNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "subdir", "deep")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "file.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := checkIsEmptyDir(dir)
+	if err != nil {
+		t.Fatalf("checkIsEmptyDir() unexpected error = %v", err)
+	}
+	if got {
+		t.Errorf("checkIsEmptyDir() = true, want false for directory with nested file")
+	}
+}
+
+func Test_checkIsEmptyDir_nestedEmpty(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := checkIsEmptyDir(dir)
+	if err != nil {
+		t.Fatalf("checkIsEmptyDir() error = %v", err)
+	}
+	if !got {
+		t.Errorf("checkIsEmptyDir() = %v, want true", got)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

`checkIsEmptyDir` (used by `isConfigFile`) had two recursion bugs:

1) It recursed with child name instead of `filepath.Join(parent, child),` and
2) It ignored nested recursion boolean results.

This change fixes both, so nested non-empty directories are correctly classified as non-empty and are not skipped due to bad recursion paths. Tests added for nested directory root classification in `isConfigFile`, fixture-based nested directory checks, and hermetic tempdir nested empty/non-empty cases.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
#### Special notes for your reviewer:
