### PR TITLE
fix: ensure unique mountPath when service has multiple secrets

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -931,38 +931,31 @@ func (k *Kubernetes) getSecretPathsLegacy(secretConfig types.ServiceSecretConfig
 	// docker-compose results, but some people might depend on this behavior so this is kept here for compatibility.
 	// See https://github.com/kubernetes/kompose/issues/1280 for more details.
 
-	var itemPath string // should be the filename
-	var mountPath = ""  // should be the directory
-	// if is used the short-syntax
+	var itemPath, mountPath string
+
+	// short-syntax (no target): place at /run/secrets/<source>
 	if secretConfig.Target == "" {
-		// the secret path (mountPath) should be inside the default directory /run/secrets
 		mountPath = "/run/secrets/" + secretConfig.Source
-		// the itemPath should be the source itself
 		itemPath = secretConfig.Source
-	} else {
-		// if is the long-syntax, i should get the last part of path and consider it the filename
-		pathSplitted := strings.Split(secretConfig.Target, "/")
-		lastPart := pathSplitted[len(pathSplitted)-1]
-
-		// if the filename (lastPart) and the target is the same
-		if lastPart == secretConfig.Target {
-			// the secret path should be the source (it need to be inside a directory and only the filename was given)
-			mountPath = secretConfig.Source
-		} else {
-			// should then get the target without the filename (lastPart)
-			mountPath = mountPath + strings.TrimSuffix(secretConfig.Target, "/"+lastPart) // menos ultima parte
-		}
-
-		// if the target isn't absolute path
-		if !strings.HasPrefix(secretConfig.Target, "/") {
-			// concat the default secret directory
-			mountPath = "/run/secrets/" + mountPath
-		}
-
-		itemPath = lastPart
+		secretSubPath = itemPath
+		return itemPath, mountPath, secretSubPath
 	}
 
-	secretSubPath = itemPath //"" // We didn't set a SubPath in legacy behavior
+	// long-syntax: derive the filename from the target path.
+	pathSplitted := strings.Split(secretConfig.Target, "/")
+	itemPath = pathSplitted[len(pathSplitted)-1]
+
+	// Use the full target as the mountPath so that multiple secrets mounted in
+	// the same parent directory each get a unique mountPath (Kubernetes requires
+	// volumeMounts[*].mountPath to be unique). The SubPath below selects the
+	// file within the secret's data, so the file still lands at mountPath.
+	// See https://github.com/kubernetes/kompose/issues/1894.
+	mountPath = secretConfig.Target
+	if !strings.HasPrefix(secretConfig.Target, "/") {
+		mountPath = "/run/secrets/" + mountPath
+	}
+
+	secretSubPath = itemPath
 	return itemPath, mountPath, secretSubPath
 }
 

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -1230,6 +1230,87 @@ func TestKubernetes_CreateSecrets(t *testing.T) {
 	}
 }
 
+// TestConfigSecretVolumes verifies that multiple secrets produce unique mountPaths.
+// See https://github.com/kubernetes/kompose/issues/1894.
+func TestConfigSecretVolumes(t *testing.T) {
+	tests := []struct {
+		name       string
+		secrets    []types.ServiceSecretConfig
+		wantMounts []api.VolumeMount
+	}{
+		{
+			name: "multiple short-syntax secrets get unique mountPaths (issue #1894)",
+			secrets: []types.ServiceSecretConfig{
+				{Source: "secret1", Target: "/run/secrets/secret1"},
+				{Source: "secret2", Target: "/run/secrets/secret2"},
+			},
+			wantMounts: []api.VolumeMount{
+				{Name: "secret1", MountPath: "/run/secrets/secret1", SubPath: "secret1"},
+				{Name: "secret2", MountPath: "/run/secrets/secret2", SubPath: "secret2"},
+			},
+		},
+		{
+			name: "single short-syntax secret",
+			secrets: []types.ServiceSecretConfig{
+				{Source: "only", Target: "/run/secrets/only"},
+			},
+			wantMounts: []api.VolumeMount{
+				{Name: "only", MountPath: "/run/secrets/only", SubPath: "only"},
+			},
+		},
+		{
+			name: "long-syntax with simple-name target (workaround for #1894)",
+			secrets: []types.ServiceSecretConfig{
+				{Source: "secret1", Target: "secret1"},
+				{Source: "secret2", Target: "secret2"},
+			},
+			wantMounts: []api.VolumeMount{
+				{Name: "secret1", MountPath: "/run/secrets/secret1", SubPath: "secret1"},
+				{Name: "secret2", MountPath: "/run/secrets/secret2", SubPath: "secret2"},
+			},
+		},
+		{
+			name: "long-syntax with absolute custom-path targets in same directory",
+			secrets: []types.ServiceSecretConfig{
+				{Source: "a", Target: "/etc/configs/a"},
+				{Source: "b", Target: "/etc/configs/b"},
+			},
+			wantMounts: []api.VolumeMount{
+				{Name: "a", MountPath: "/etc/configs/a", SubPath: "a"},
+				{Name: "b", MountPath: "/etc/configs/b", SubPath: "b"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &Kubernetes{}
+			service := kobject.ServiceConfig{Secrets: tt.secrets}
+			gotMounts, _ := k.ConfigSecretVolumes("test-service", service)
+
+			if len(gotMounts) != len(tt.wantMounts) {
+				t.Fatalf("got %d volumeMounts, want %d (got=%+v)", len(gotMounts), len(tt.wantMounts), gotMounts)
+			}
+			seen := map[string]bool{}
+			for i, vm := range gotMounts {
+				if vm.MountPath != tt.wantMounts[i].MountPath {
+					t.Errorf("mounts[%d].MountPath = %q, want %q", i, vm.MountPath, tt.wantMounts[i].MountPath)
+				}
+				if vm.SubPath != tt.wantMounts[i].SubPath {
+					t.Errorf("mounts[%d].SubPath = %q, want %q", i, vm.SubPath, tt.wantMounts[i].SubPath)
+				}
+				if vm.Name != tt.wantMounts[i].Name {
+					t.Errorf("mounts[%d].Name = %q, want %q", i, vm.Name, tt.wantMounts[i].Name)
+				}
+				if seen[vm.MountPath] {
+					t.Errorf("duplicate mountPath %q across mounts (Kubernetes requires uniqueness)", vm.MountPath)
+				}
+				seen[vm.MountPath] = true
+			}
+		})
+	}
+}
+
 // struct defines the configuration parameters required for creating a secret
 type SecretsConfig struct {
 	nameSecretConfig string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a service references multiple secrets, compose-go normalizes
short-syntax `secrets: [a, b]` to long-syntax with
`Target="/run/secrets/<name>"`. `getSecretPathsLegacy` then stripped the
filename and used only the parent directory as `mountPath`, so both
secrets ended up with `mountPath: /run/secrets` and `kubectl apply` failed
with `volumeMounts[*].mountPath: must be unique`.

Use the full target as the mountPath. SubPath still selects the file
within the secret data, so the file lands at the same location.

#### Which issue(s) this PR fixes:

Fixes #1894